### PR TITLE
Add support for basic modelBuilder functionality

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -15,38 +15,36 @@ func buildPathsAndDefs(ws *restful.WebService) (spec.Paths, spec.Definitions) {
 	p := spec.Paths{Paths: map[string]spec.PathItem{}}
 	d := spec.Definitions{}
 	for _, each := range ws.Routes() {
-		p.Paths[each.Path] = buildPathItem(ws, each)
+		op := buildOperation(ws, each)
+		existingPathItem, ok := p.Paths[each.Path]
+		if !ok {
+			existingPathItem = spec.PathItem{}
+		}
+
+		switch each.Method {
+		case "GET":
+			existingPathItem.Get = op
+		case "POST":
+			existingPathItem.Post = op
+		case "PUT":
+			existingPathItem.Put = op
+		case "DELETE":
+			existingPathItem.Delete = op
+		case "PATCH":
+			existingPathItem.Patch = op
+		case "OPTIONS":
+			existingPathItem.Options = op
+		case "HEAD":
+			existingPathItem.Head = op
+		}
+
+		p.Paths[each.Path] = existingPathItem
 		definitions := buildDefinitions(ws, each)
 		for name, defn := range definitions {
 			d[name] = defn
 		}
 	}
 	return p, d
-}
-
-func buildPathItem(ws *restful.WebService, r restful.Route) spec.PathItem {
-	op := buildOperation(ws, r)
-	props := spec.PathItemProps{}
-	switch r.Method {
-	case "GET":
-		props.Get = op
-	case "POST":
-		props.Post = op
-	case "PUT":
-		props.Put = op
-	case "DELETE":
-		props.Delete = op
-	case "PATCH":
-		props.Patch = op
-	case "OPTIONS":
-		props.Options = op
-	case "HEAD":
-		props.Head = op
-	}
-	p := spec.PathItem{
-		PathItemProps: props,
-	}
-	return p
 }
 
 func buildOperation(ws *restful.WebService, r restful.Route) *spec.Operation {

--- a/config.go
+++ b/config.go
@@ -22,6 +22,10 @@ type PostBuildSwaggerObjectFunc func(s *spec.Swagger)
 
 // Config holds service api metadata.
 type Config struct {
+	// [optional] path where the swagger UI will be served, e.g. /swagger
+	SwaggerPath string
+	// [optional] location of folder containing Swagger HTML5 application index.html
+	SwaggerFilePath string
 	// WebServicesURL is the url where the services are available, e.g. http://localhost:8080
 	// if left empty then the basePath of Swagger is taken from the actual request
 	WebServicesURL string
@@ -39,4 +43,6 @@ type Config struct {
 	ModelTypeNameHandler MapModelTypeNameFunc
 	// [optional] If set then call this function with the generated Swagger Object
 	PostBuildSwaggerObjectHandler PostBuildSwaggerObjectFunc
+	// Info sets top-level information about this API
+	Info spec.Info
 }

--- a/model_builder.go
+++ b/model_builder.go
@@ -1,0 +1,446 @@
+package restfulspec
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/go-openapi/spec"
+)
+
+type modelBuilder struct {
+	Definitions spec.Definitions
+	Config      *Config
+}
+
+type documentable interface {
+	SwaggerDoc() map[string]string
+}
+
+// Check if this structure has a method with signature func (<theModel>) SwaggerDoc() map[string]string
+// If it exists, retrive the documentation and overwrite all struct tag descriptions
+func getDocFromMethodSwaggerDoc2(model reflect.Type) map[string]string {
+	if docable, ok := reflect.New(model).Elem().Interface().(documentable); ok {
+		return docable.SwaggerDoc()
+	}
+	return make(map[string]string)
+}
+
+// addModelFrom creates and adds a Schema to the builder and detects and calls
+// the post build hook for customizations
+func (b modelBuilder) addModelFrom(sample interface{}) {
+	b.addModel(reflect.TypeOf(sample), "")
+}
+
+func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *spec.Schema {
+	// Turn pointers into simpler types so further checks are
+	// correct.
+	if st.Kind() == reflect.Ptr {
+		st = st.Elem()
+	}
+
+	modelName := b.keyFrom(st)
+	if nameOverride != "" {
+		modelName = nameOverride
+	}
+	// no models needed for primitive types
+	if b.isPrimitiveType(modelName) {
+		return nil
+	}
+	// golang encoding/json packages says array and slice values encode as
+	// JSON arrays, except that []byte encodes as a base64-encoded string.
+	// If we see a []byte here, treat it at as a primitive type (string)
+	// and deal with it in buildArrayTypeProperty.
+	if (st.Kind() == reflect.Slice || st.Kind() == reflect.Array) &&
+		st.Elem().Kind() == reflect.Uint8 {
+		return nil
+	}
+	// see if we already have visited this model
+	if _, ok := b.Definitions[modelName]; ok {
+		return nil
+	}
+	sm := spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			ID:         modelName,
+			Required:   []string{},
+			Properties: map[string]spec.Schema{},
+		},
+	}
+
+	// reference the model before further initializing (enables recursive structs)
+	b.Definitions[modelName] = sm
+
+	// check for slice or array
+	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
+		b.addModel(st.Elem(), "")
+		return &sm
+	}
+	// check for structure or primitive type
+	if st.Kind() != reflect.Struct {
+		return &sm
+	}
+
+	fullDoc := getDocFromMethodSwaggerDoc2(st)
+	modelDescriptions := []string{}
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		jsonName, modelDescription, prop := b.buildProperty(field, &sm, modelName)
+		if len(modelDescription) > 0 {
+			modelDescriptions = append(modelDescriptions, modelDescription)
+		}
+
+		// add if not omitted
+		if len(jsonName) != 0 {
+			// update description
+			if fieldDoc, ok := fullDoc[jsonName]; ok {
+				prop.Description = fieldDoc
+			}
+			// update Required
+			if b.isPropertyRequired(field) {
+				sm.Required = append(sm.Required, jsonName)
+			}
+			sm.Properties[jsonName] = prop
+		}
+	}
+
+	// We always overwrite documentation if SwaggerDoc method exists
+	// "" is special for documenting the struct itself
+	if modelDoc, ok := fullDoc[""]; ok {
+		sm.Description = modelDoc
+	} else if len(modelDescriptions) != 0 {
+		sm.Description = strings.Join(modelDescriptions, "\n")
+	}
+
+	// update model builder with completed model
+	b.Definitions[modelName] = sm
+
+	return &sm
+}
+
+func (b modelBuilder) isPropertyRequired(field reflect.StructField) bool {
+	required := true
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "omitempty" {
+			return false
+		}
+	}
+	return required
+}
+
+func (b modelBuilder) buildProperty(field reflect.StructField, model *spec.Schema, modelName string) (jsonName, modelDescription string, prop spec.Schema) {
+	jsonName = b.jsonNameOfField(field)
+	if len(jsonName) == 0 {
+		// empty name signals skip property
+		return "", "", prop
+	}
+
+	if field.Name == "XMLName" && field.Type.String() == "xml.Name" {
+		// property is metadata for the xml.Name attribute, can be skipped
+		return "", "", prop
+	}
+
+	if tag := field.Tag.Get("modelDescription"); tag != "" {
+		modelDescription = tag
+	}
+
+	fieldType := field.Type
+
+	// check if type is doing its own marshalling
+	marshalerType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	if fieldType.Implements(marshalerType) {
+		var pType = "string"
+		if prop.Type == nil {
+			prop.Type = []string{pType}
+		}
+		if prop.Format == "" {
+			prop.Format = b.jsonSchemaFormat(b.keyFrom(fieldType))
+		}
+		return jsonName, modelDescription, prop
+	}
+
+	// check if annotation says it is a string
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "string" {
+			stringt := "string"
+			prop.Type = []string{stringt}
+			return jsonName, modelDescription, prop
+		}
+	}
+
+	fieldKind := fieldType.Kind()
+	switch {
+	case fieldKind == reflect.Struct:
+		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Slice || fieldKind == reflect.Array:
+		jsonName, prop := b.buildArrayTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Ptr:
+		jsonName, prop := b.buildPointerTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.String:
+		stringt := "string"
+		prop.Type = []string{stringt}
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Map:
+		// if it's a map, it's unstructured, and swagger can't handle it
+		objectType := "object"
+		prop.Type = []string{objectType}
+		return jsonName, modelDescription, prop
+	}
+
+	fieldTypeName := b.keyFrom(fieldType)
+	if b.isPrimitiveType(fieldTypeName) {
+		mapped := b.jsonSchemaType(fieldTypeName)
+		prop.Type = []string{mapped}
+		prop.Format = b.jsonSchemaFormat(fieldTypeName)
+		return jsonName, modelDescription, prop
+	}
+	modelType := b.keyFrom(fieldType)
+	prop.Ref = spec.MustCreateRef("#/definitions/" + modelType)
+
+	if fieldType.Name() == "" { // override type of anonymous structs
+		nestedTypeName := modelName + "." + jsonName
+		prop.Ref = spec.MustCreateRef("#/definitions/" + nestedTypeName)
+		b.addModel(fieldType, nestedTypeName)
+	}
+	return jsonName, modelDescription, prop
+}
+
+func hasNamedJSONTag(field reflect.StructField) bool {
+	parts := strings.Split(field.Tag.Get("json"), ",")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, s := range parts[1:] {
+		if s == "inline" {
+			return false
+		}
+	}
+	return len(parts[0]) > 0
+}
+
+func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonName string, model *spec.Schema) (nameJson string, prop spec.Schema) {
+	fieldType := field.Type
+	// check for anonymous
+	if len(fieldType.Name()) == 0 {
+		// anonymous
+		anonType := model.ID + "." + jsonName
+		b.addModel(fieldType, anonType)
+		prop.Ref = spec.MustCreateRef("#/definitions/" + anonType)
+		return jsonName, prop
+	}
+
+	if field.Name == fieldType.Name() && field.Anonymous && !hasNamedJSONTag(field) {
+		// embedded struct
+		sub := modelBuilder{make(spec.Definitions), b.Config}
+		sub.addModel(fieldType, "")
+		subKey := sub.keyFrom(fieldType)
+		// merge properties from sub
+		subModel, _ := sub.Definitions[subKey]
+		for k, v := range subModel.Properties {
+			model.Properties[k] = v
+			// if subModel says this property is required then include it
+			required := false
+			for _, each := range subModel.Required {
+				if k == each {
+					required = true
+					break
+				}
+			}
+			if required {
+				model.Required = append(model.Required, k)
+			}
+		}
+		// add all new referenced models
+		for key, sub := range sub.Definitions {
+			if key != subKey {
+				if _, ok := b.Definitions[key]; !ok {
+					b.Definitions[key] = sub
+				}
+			}
+		}
+		// empty name signals skip property
+		return "", prop
+	}
+	// simple struct
+	b.addModel(fieldType, "")
+	var pType = b.keyFrom(fieldType)
+	prop.Ref = spec.MustCreateRef("#/definitions/" + pType)
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
+	fieldType := field.Type
+	if fieldType.Elem().Kind() == reflect.Uint8 {
+		stringt := "string"
+		prop.Type = []string{stringt}
+		return jsonName, prop
+	}
+	var pType = "array"
+	prop.Type = []string{pType}
+	isPrimitive := b.isPrimitiveType(fieldType.Elem().Name())
+	elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
+	prop.Items = &spec.SchemaOrArray{
+		Schema: &spec.Schema{},
+	}
+	if isPrimitive {
+		mapped := b.jsonSchemaType(elemTypeName)
+		prop.Items.Schema.Type = []string{mapped}
+	} else {
+		prop.Items.Schema.Ref = spec.MustCreateRef("#/definitions/" + elemTypeName)
+	}
+	// add|overwrite model for element type
+	if fieldType.Elem().Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+	if !isPrimitive {
+		b.addModel(fieldType.Elem(), elemTypeName)
+	}
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
+	fieldType := field.Type
+
+	// override type of pointer to list-likes
+	if fieldType.Elem().Kind() == reflect.Slice || fieldType.Elem().Kind() == reflect.Array {
+		var pType = "array"
+		prop.Type = []string{pType}
+		isPrimitive := b.isPrimitiveType(fieldType.Elem().Elem().Name())
+		elemName := b.getElementTypeName(modelName, jsonName, fieldType.Elem().Elem())
+		prop.Items = &spec.SchemaOrArray{
+			Schema: &spec.Schema{},
+		}
+		if isPrimitive {
+			primName := b.jsonSchemaType(elemName)
+			prop.Items.Schema.Ref = spec.MustCreateRef("#/definitions/" + primName)
+		} else {
+			prop.Items.Schema.Ref = spec.MustCreateRef("#/definitions/" + elemName)
+		}
+		if !isPrimitive {
+			// add|overwrite model for element type
+			b.addModel(fieldType.Elem().Elem(), elemName)
+		}
+	} else {
+		// non-array, pointer type
+		fieldTypeName := b.keyFrom(fieldType.Elem())
+		var pType = b.jsonSchemaType(fieldTypeName) // no star, include pkg path
+		if b.isPrimitiveType(fieldTypeName) {
+			prop.Type = []string{pType}
+			prop.Format = b.jsonSchemaFormat(fieldTypeName)
+			return jsonName, prop
+		}
+		prop.Ref = spec.MustCreateRef("#/definitions/" + pType)
+		elemName := ""
+		if fieldType.Elem().Name() == "" {
+			elemName = modelName + "." + jsonName
+			prop.Ref = spec.MustCreateRef("#/definitions/" + elemName)
+		}
+		b.addModel(fieldType.Elem(), elemName)
+	}
+	return jsonName, prop
+}
+
+func (b modelBuilder) getElementTypeName(modelName, jsonName string, t reflect.Type) string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Name() == "" {
+		return modelName + "." + jsonName
+	}
+	return b.keyFrom(t)
+}
+
+func (b modelBuilder) keyFrom(st reflect.Type) string {
+	key := st.String()
+	if b.Config != nil && b.Config.ModelTypeNameHandler != nil {
+		if name, ok := b.Config.ModelTypeNameHandler(st); ok {
+			key = name
+		}
+	}
+	if len(st.Name()) == 0 { // unnamed type
+		// Swagger UI has special meaning for [
+		key = strings.Replace(key, "[]", "||", -1)
+	}
+	return key
+}
+
+// see also https://golang.org/ref/spec#Numeric_types
+func (b modelBuilder) isPrimitiveType(modelName string) bool {
+	if len(modelName) == 0 {
+		return false
+	}
+	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time", modelName)
+}
+
+// jsonNameOfField returns the name of the field as it should appear in JSON format
+// An empty string indicates that this field is not part of the JSON representation
+func (b modelBuilder) jsonNameOfField(field reflect.StructField) string {
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if s[0] == "-" {
+			// empty name signals skip property
+			return ""
+		} else if s[0] != "" {
+			return s[0]
+		}
+	}
+	return field.Name
+}
+
+// see also http://json-schema.org/latest/json-schema-core.html#anchor8
+func (b modelBuilder) jsonSchemaType(modelName string) string {
+	schemaMap := map[string]string{
+		"uint":   "integer",
+		"uint8":  "integer",
+		"uint16": "integer",
+		"uint32": "integer",
+		"uint64": "integer",
+
+		"int":   "integer",
+		"int8":  "integer",
+		"int16": "integer",
+		"int32": "integer",
+		"int64": "integer",
+
+		"byte":      "integer",
+		"float64":   "number",
+		"float32":   "number",
+		"bool":      "boolean",
+		"time.Time": "string",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return modelName // use as is (custom or struct)
+	}
+	return mapped
+}
+
+func (b modelBuilder) jsonSchemaFormat(modelName string) string {
+	if b.Config != nil && b.Config.SchemaFormatHandler != nil {
+		if mapped := b.Config.SchemaFormatHandler(modelName); mapped != "" {
+			return mapped
+		}
+	}
+	schemaMap := map[string]string{
+		"int":        "int32",
+		"int32":      "int32",
+		"int64":      "int64",
+		"byte":       "byte",
+		"uint":       "integer",
+		"uint8":      "byte",
+		"float64":    "double",
+		"float32":    "float",
+		"time.Time":  "date-time",
+		"*time.Time": "date-time",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return "" // no format
+	}
+	return mapped
+}

--- a/spec_resource.go
+++ b/spec_resource.go
@@ -1,7 +1,11 @@
 package restfulspec
 
-import restful "github.com/emicklei/go-restful"
-import "github.com/go-openapi/spec"
+import (
+	"net/http"
+
+	restful "github.com/emicklei/go-restful"
+	"github.com/go-openapi/spec"
+)
 
 // RegisterOpenAPIService adds the WebService that provides the API documentation of all services
 // conform the OpenAPI documentation specifcation.
@@ -14,17 +18,46 @@ func RegisterOpenAPIService(config Config, wsContainer *restful.Container) {
 		ws.Filter(enableCORS)
 	}
 
-	res := specResource{config: config, paths: spec.Paths{Paths: map[string]spec.PathItem{}}}
-	ws.Route(ws.GET("/").To(res.getSwagger))
-
 	// TEMP
+	paths := spec.Paths{Paths: map[string]spec.PathItem{}}
+	definitions := spec.Definitions{}
 	for _, each := range config.WebServices {
-		po := buildPaths(each)
+		po, defs := buildPathsAndDefs(each)
 		for path, item := range po.Paths {
-			res.paths.Paths[path] = item
+			paths.Paths[path] = item
+		}
+		for name, d := range defs {
+			definitions[name] = d
 		}
 	}
+
+	sw := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Swagger:     "2.0",
+			Paths:       &paths,
+			Definitions: definitions,
+			Info:        &config.Info,
+		},
+	}
+	if config.PostBuildSwaggerObjectHandler != nil {
+		config.PostBuildSwaggerObjectHandler(sw)
+	}
+
+	res := specResource{swaggerSpec: sw}
+	ws.Route(ws.GET("/").To(res.getSwagger))
+
 	wsContainer.Add(ws)
+
+	// Check paths for UI serving
+	if config.SwaggerFilePath != "" && config.SwaggerPath != "" {
+		swaggerPathSlash := config.SwaggerPath
+		// path must end with slash /
+		if "/" != config.SwaggerPath[len(config.SwaggerPath)-1:] {
+			swaggerPathSlash += "/"
+		}
+
+		wsContainer.Handle(swaggerPathSlash, http.StripPrefix(swaggerPathSlash, http.FileServer(http.Dir(config.SwaggerFilePath))))
+	}
 }
 
 func enableCORS(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
@@ -39,19 +72,9 @@ func enableCORS(req *restful.Request, resp *restful.Response, chain *restful.Fil
 
 // specResource is a REST resource to serve the Open-API spec.
 type specResource struct {
-	config Config
-	paths  spec.Paths
+	swaggerSpec *spec.Swagger
 }
 
 func (s specResource) getSwagger(req *restful.Request, resp *restful.Response) {
-	sw := &spec.Swagger{
-		SwaggerProps: spec.SwaggerProps{
-			Swagger: "2.0",
-			Paths:   &(s.paths),
-		},
-	}
-	if s.config.PostBuildSwaggerObjectHandler != nil {
-		s.config.PostBuildSwaggerObjectHandler(sw)
-	}
-	resp.WriteAsJson(sw)
+	resp.WriteAsJson(s.swaggerSpec)
 }


### PR DESCRIPTION
This brings this library more in line with go-restful-swagger12

Also added support for static UI path handling and only ran the
PostBuildSwaggerObjectHandler function once rather than on every request