### PR TITLE
Fix return code mapping

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -70,7 +70,7 @@ func buildOperation(ws *restful.WebService, r restful.Route) *spec.Operation {
 		o.Parameters = append(o.Parameters, buildParameter(each))
 	}
 	o.Responses = new(spec.Responses)
-	props := o.Responses.ResponsesProps
+	props := &o.Responses.ResponsesProps
 	props.StatusCodeResponses = map[int]spec.Response{}
 	for k, v := range r.ResponseErrors {
 		r := buildResponse(v)

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -35,6 +35,7 @@ func TestMultipleMethodsRouteToPath(t *testing.T) {
 	ws.Route(ws.POST("/a/b").To(dummy).
 		Doc("post a b test").
 		Returns(200, "list of a b tests", []Sample{}).
+		Returns(500, "internal server error", []Sample{}).
 		Writes([]Sample{}))
 
 	p := buildPaths(ws)
@@ -45,5 +46,8 @@ func TestMultipleMethodsRouteToPath(t *testing.T) {
 	}
 	if p.Paths["/tests/a/a/b"].Post.Description != "post a b test" {
 		t.Errorf("POST description incorrect")
+	}
+	if _, exists := p.Paths["/tests/a/a/b"].Post.Responses.StatusCodeResponses[500]; !exists {
+		t.Errorf("Response code 500 not added to spec.")
 	}
 }


### PR DESCRIPTION
Add the response codes to a pointer of the ResponsesProps, otherwise they
are only added to a copy of the ResponsesProps.