### PR TITLE
Some property fixes

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -107,17 +107,18 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, cfg Config
 	p := spec.Parameter{}
 	param := restfulParam.Data()
 	p.In = asParamType(param.Kind)
-	p.Type = param.DataType
 	p.Description = param.Description
 	p.Name = param.Name
 	p.Required = param.Required
-	p.Default = stringAutoType(param.DefaultValue)
-	p.Format = param.DataFormat
 
-	if p.In == "body" && r.ReadSample != nil && p.Type == reflect.TypeOf(r.ReadSample).String() {
+	if param.Kind == restful.BodyParameterKind && r.ReadSample != nil && param.DataType == reflect.TypeOf(r.ReadSample).String() {
 		p.Schema = new(spec.Schema)
-		p.Schema.Ref = spec.MustCreateRef("#/definitions/" + p.Type)
+		p.Schema.Ref = spec.MustCreateRef("#/definitions/" + param.DataType)
 		p.SimpleSchema = spec.SimpleSchema{}
+	} else {
+		p.Type = param.DataType
+		p.Default = stringAutoType(param.DefaultValue)
+		p.Format = param.DataFormat
 	}
 	return p
 }

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -24,6 +24,11 @@ func TestRouteToPath(t *testing.T) {
 	p := buildPaths(ws, Config{})
 	t.Log(asJSON(p))
 
+	if p.Paths["/tests/{v}/a/{b}"].Get.Parameters[0].Type != "string" {
+		t.Error("Parameter type is not set.")
+
+	}
+
 	if p.Paths["/tests/{v}/a/{b}"].Get.Description != description {
 		t.Errorf("GET description incorrect")
 	}

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	restful "github.com/emicklei/go-restful"
+	"github.com/go-openapi/spec"
 )
 
 func TestRouteToPath(t *testing.T) {
@@ -57,6 +58,7 @@ func TestMultipleMethodsRouteToPath(t *testing.T) {
 		Doc("post a b test").
 		Returns(200, "list of a b tests", []Sample{}).
 		Returns(500, "internal server error", []Sample{}).
+		Reads(Sample{}).
 		Writes([]Sample{}))
 
 	p := buildPaths(ws, Config{})
@@ -70,5 +72,16 @@ func TestMultipleMethodsRouteToPath(t *testing.T) {
 	}
 	if _, exists := p.Paths["/tests/a/a/b"].Post.Responses.StatusCodeResponses[500]; !exists {
 		t.Errorf("Response code 500 not added to spec.")
+	}
+
+	expectedRef := spec.MustCreateRef("#/definitions/restfulspec.Sample")
+	postBodyparam := p.Paths["/tests/a/a/b"].Post.Parameters[0]
+	postBodyRef := postBodyparam.Schema.Ref
+	if postBodyRef.String() != expectedRef.String() {
+		t.Errorf("Expected: %s, Got: %s", expectedRef.String(), postBodyRef.String())
+	}
+
+	if postBodyparam.Format != "" || postBodyparam.Type != "" || postBodyparam.Default != nil {
+		t.Errorf("Invalid parameter property is set on body property")
 	}
 }

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -21,13 +21,22 @@ func TestRouteToPath(t *testing.T) {
 		Param(ws.QueryParameter("q", "value of q").DefaultValue("default-q")).
 		Returns(200, "list of a b tests", []Sample{}).
 		Writes([]Sample{}))
+	ws.Route(ws.GET("/a/{b}/{c:[a-z]+}/{d:[1-9]+}/e").To(dummy).
+		Doc("get the a b test").
+		Param(ws.PathParameter("b", "value of b").DefaultValue("default-b")).
+		Param(ws.PathParameter("c", "with regex").DefaultValue("abc")).
+		Param(ws.QueryParameter("q", "value of q").DefaultValue("default-q")).
+		Returns(200, "list of a b tests", []Sample{}).
+		Writes([]Sample{}))
 
 	p := buildPaths(ws, Config{})
 	t.Log(asJSON(p))
 
 	if p.Paths["/tests/{v}/a/{b}"].Get.Parameters[0].Type != "string" {
 		t.Error("Parameter type is not set.")
-
+	}
+	if _, exists := p.Paths["/tests/{v}/a/{b}/{c}/{d}/e"]; !exists {
+		t.Error("Expected path to exist after it was sanitized.")
 	}
 
 	if p.Paths["/tests/{v}/a/{b}"].Get.Description != description {


### PR DESCRIPTION
See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-object for details.

 * Set type parameter on properties
 * When parameter is the body, only set allowed properties
 * When parameter is the body, set the schema
 * Make sure that the regex part of path parameters is not included in the string
 * Add tests