### PR TITLE
Fix pointer type in building schema.ref

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -98,6 +98,11 @@ func buildResponse(e restful.ResponseError) (r spec.Response) {
 	r.Description = e.Message
 	if e.Model != nil {
 		st := reflect.TypeOf(e.Model)
+		if st.Kind() == reflect.Ptr {
+			// For pointer type, use element type as the key; otherwise we'll
+			// endup with '#/definitions/*Type' which violates openapi spec.
+			st = st.Elem()
+		}
 		modelName := definitionBuilder{}.keyFrom(st)
 		r.Schema = new(spec.Schema)
 		r.Schema.Ref = spec.MustCreateRef("#/definitions/" + modelName)


### PR DESCRIPTION
Partially addresses https://github.com/emicklei/go-restful-openapi/issues/13

For test, can we import https://github.com/go-openapi/validate to do more validations?