### PR TITLE
Strip HTML tags from the summary

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -3,6 +3,7 @@ package restfulspec
 import (
 	"net/http"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -49,9 +50,9 @@ func buildPathItem(ws *restful.WebService, r restful.Route, existingPathItem spe
 func buildOperation(ws *restful.WebService, r restful.Route, cfg Config) *spec.Operation {
 	o := spec.NewOperation(r.Operation)
 	o.Description = r.Doc
-	// take the first line to be the summary
+	// take the first line (stripping HTML tags) to be the summary
 	if lines := strings.Split(r.Doc, "\n"); len(lines) > 0 {
-		o.Summary = lines[0]
+		o.Summary = stripTags(lines[0])
 	}
 	o.Consumes = r.Consumes
 	o.Produces = r.Produces
@@ -143,4 +144,11 @@ func buildResponse(e restful.ResponseError, cfg Config) (r spec.Response) {
 		}
 	}
 	return r
+}
+
+// stripTags takes a snippet of HTML and returns only the text content.
+// For example, `<b>&lt;Hi!&gt;</b> <br>` -> `&lt;Hi!&gt; `.
+func stripTags(html string) string {
+	re := regexp.MustCompile("<[^>]*>")
+	return re.ReplaceAllString(html, "")
 }

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -7,13 +7,15 @@ import (
 )
 
 func TestRouteToPath(t *testing.T) {
+	description := "get the <strong>a</strong> <em>b</em> test\nthis is the test description"
+
 	ws := new(restful.WebService)
 	ws.Path("/tests/{v}")
 	ws.Param(ws.PathParameter("v", "value of v").DefaultValue("default-v"))
 	ws.Consumes(restful.MIME_JSON)
 	ws.Produces(restful.MIME_XML)
 	ws.Route(ws.GET("/a/{b}").To(dummy).
-		Doc("get the a b test").
+		Doc(description).
 		Param(ws.PathParameter("b", "value of b").DefaultValue("default-b")).
 		Param(ws.QueryParameter("q", "value of q").DefaultValue("default-q")).
 		Returns(200, "list of a b tests", []Sample{}).
@@ -22,8 +24,11 @@ func TestRouteToPath(t *testing.T) {
 	p := buildPaths(ws, Config{})
 	t.Log(asJSON(p))
 
-	if p.Paths["/tests/{v}/a/{b}"].Get.Description != "get the a b test" {
+	if p.Paths["/tests/{v}/a/{b}"].Get.Description != description {
 		t.Errorf("GET description incorrect")
+	}
+	if p.Paths["/tests/{v}/a/{b}"].Get.Summary != "get the a b test" {
+		t.Errorf("GET summary incorrect")
 	}
 	response := p.Paths["/tests/{v}/a/{b}"].Get.Responses.StatusCodeResponses[200]
 	if response.Schema.Type[0] != "array" {


### PR DESCRIPTION
Summary is built from the first line of the description
(defined using `Doc()` in the `RouteBuilder`).

Description may contain HTML, for emphasis in Swagger-UI
(or any other visualization tool), thus they should
be stripped from the one-line summary.

This is performed using a very basic regexp which removes
all `"<[^>]>"` patterns.