### PR TITLE
go-swagger api client generator compatability

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -1,6 +1,7 @@
 package restfulspec
 
 import (
+	"net/http"
 	"reflect"
 	"strings"
 
@@ -77,6 +78,9 @@ func buildOperation(ws *restful.WebService, r restful.Route, cfg Config) *spec.O
 		if 200 == k { // any 2xx code?
 			o.Responses.Default = &r
 		}
+	}
+	if len(o.Responses.StatusCodeResponses) == 0 {
+		o.Responses.StatusCodeResponses[200] = spec.Response{ResponseProps: spec.ResponseProps{Description: http.StatusText(http.StatusOK)}}
 	}
 	return o
 }

--- a/build_path.go
+++ b/build_path.go
@@ -111,9 +111,11 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, cfg Config
 	p.Required = param.Required
 	p.Default = stringAutoType(param.DefaultValue)
 	p.Format = param.DataFormat
+
 	if p.In == "body" && r.ReadSample != nil && p.Type == reflect.TypeOf(r.ReadSample).String() {
 		p.Schema = new(spec.Schema)
 		p.Schema.Ref = spec.MustCreateRef("#/definitions/" + p.Type)
+		p.SimpleSchema = spec.SimpleSchema{}
 	}
 	return p
 }

--- a/build_path.go
+++ b/build_path.go
@@ -3,6 +3,7 @@ package restfulspec
 import (
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 
 	restful "github.com/emicklei/go-restful"
@@ -93,7 +94,15 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, cfg Config
 	p.Description = param.Description
 	p.Name = param.Name
 	p.Required = param.Required
-	p.Default = param.DefaultValue
+	if param.DefaultValue != "" {
+		if parsedInt, err := strconv.ParseInt(param.DefaultValue, 10, 64); err == nil {
+			p.Default = parsedInt
+		} else if parsedBool, err := strconv.ParseBool(param.DefaultValue); err == nil {
+			p.Default = parsedBool
+		} else {
+			p.Default = param.DefaultValue
+		}
+	}
 	p.Format = param.DataFormat
 	if p.In == "body" && r.ReadSample != nil && p.Type == reflect.TypeOf(r.ReadSample).String() {
 		p.Schema = new(spec.Schema)

--- a/examples/user-resource.go
+++ b/examples/user-resource.go
@@ -33,7 +33,7 @@ func (u UserResource) WebService() *restful.WebService {
 	ws.Route(ws.GET("/{user-id}").To(u.findUser).
 		// docs
 		Doc("get a user").
-		Param(ws.PathParameter("user-id", "identifier of the user").DataType("string")).
+		Param(ws.PathParameter("user-id", "identifier of the user").DataType("integer").DefaultValue("1")).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(User{}). // on the response
 		Returns(200, "OK", User{}).
@@ -132,7 +132,7 @@ func main() {
 	// Optionally, you can install the Swagger Service which provides a nice Web UI on your REST API
 	// You need to download the Swagger HTML5 assets and change the FilePath location in the config below.
 	// Open http://localhost:8080/apidocs/?url=http://localhost:8080/apidocs.json
-	http.Handle("/apidocs/", http.StripPrefix("/apidocs/", http.FileServer(http.Dir("/Users/emicklei/xProjects/swagger-ui/dist"))))
+	http.Handle("/apidocs/", http.StripPrefix("/apidocs/", http.FileServer(http.Dir("/home/v/Downloads/swagger-ui"))))
 
 	log.Printf("start listening on localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
@@ -163,5 +163,6 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 // User is just a sample type
 type User struct {
 	ID   string `json:"id" description:"identifier of the user"`
-	Name string `json:"name" description:"name of the user"`
+	Name string `json:"name" description:"name of the user" default:"john"`
+	Age  int    `json:"age" description:"age of the user" default:"21"`
 }

--- a/lookup.go
+++ b/lookup.go
@@ -13,7 +13,7 @@ func asParamType(kind int) string {
 	case kind == restful.HeaderParameterKind:
 		return "header"
 	case kind == restful.FormParameterKind:
-		return "form"
+		return "formData"
 	}
 	return ""
 }

--- a/property_ext.go
+++ b/property_ext.go
@@ -16,7 +16,7 @@ func setDescription(prop *spec.Schema, field reflect.StructField) {
 
 func setDefaultValue(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("default"); tag != "" {
-		prop.Default = tag
+		prop.Default = stringAutoType(tag)
 	}
 }
 


### PR DESCRIPTION
There were some spec violations in the output produced by go-restful-openapi that caused go-swagger's api client generator to fail if ran on the spec produced.

To test, run the example, then, in the example directory, run:
```bash
curl localhost:8080/apidocs.json > apidocs.json
mkdir -p client
rm -rf client/*
docker run --rm \
    -e GOPATH=/go \
    -v $(pwd):$(pwd) \
    -w $(pwd) \
    -u $(id -u):$(id -g) \
    quay.io/goswagger/swagger:0.10.0 \
        generate \
        client \
        -f apidocs.json \
        -t client
```

This PR includes #22
