### PR TITLE
Set the spec.Operation's Deprecated property based on the Route's Deprecated value

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -56,6 +56,7 @@ func buildOperation(ws *restful.WebService, r restful.Route, cfg Config) *spec.O
 	}
 	o.Consumes = r.Consumes
 	o.Produces = r.Produces
+	o.Deprecated = r.Deprecated
 	if r.Metadata != nil {
 		if tags, ok := r.Metadata[KeyOpenAPITags]; ok {
 			if tagList, ok := tags.([]string); ok {


### PR DESCRIPTION
This goes together with PR [#357](https://github.com/emicklei/go-restful/pull/357) from go-restful.  The go-restful PR should be merged first so the Deprecated property will exist on the Route struct.