### PR TITLE
Use AllowMultiple and CollectionFormat to create an array type

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -132,6 +132,14 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, pattern st
 	p := spec.Parameter{}
 	param := restfulParam.Data()
 	p.In = asParamType(param.Kind)
+	if param.AllowMultiple {
+		p.Type = "array"
+		p.Items = spec.NewItems()
+		p.Items.Type = param.DataType
+		p.CollectionFormat = param.CollectionFormat
+	} else {
+		p.Type = param.DataType
+	}
 	p.Description = param.Description
 	p.Name = param.Name
 	p.Required = param.Required


### PR DESCRIPTION
If AllowMultiple is set we can create an array type of the original type specified.  Together with CollectionFormat a repeated field can now be used in accordance with the spec.