### PR TITLE
Model ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/examples

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -72,8 +72,7 @@ func (b definitionBuilder) addModel(st reflect.Type, nameOverride string) *spec.
 
 	// check for slice or array
 	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
-		b.addModel(st.Elem(), "")
-		return &sm
+		st = st.Elem()
 	}
 	// check for structure or primitive type
 	if st.Kind() != reflect.Struct {
@@ -374,6 +373,8 @@ func (b definitionBuilder) keyFrom(st reflect.Type) string {
 		}
 	}
 	if len(st.Name()) == 0 { // unnamed type
+		// If it is an array, remove the leading []
+		key = strings.TrimPrefix(key, "[]")
 		// Swagger UI has special meaning for [
 		key = strings.Replace(key, "[]", "||", -1)
 	}

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -62,7 +62,6 @@ func (b definitionBuilder) addModel(st reflect.Type, nameOverride string) *spec.
 	}
 	sm := spec.Schema{
 		SchemaProps: spec.SchemaProps{
-			ID:         modelName,
 			Required:   []string{},
 			Properties: map[string]spec.Schema{},
 		},
@@ -112,6 +111,10 @@ func (b definitionBuilder) addModel(st reflect.Type, nameOverride string) *spec.
 	} else if len(modelDescriptions) != 0 {
 		sm.Description = strings.Join(modelDescriptions, "\n")
 	}
+	// Needed to pass openapi validation. This field exists for json-schema compatibility,
+	// but it conflicts with the openapi specification.
+	// See https://github.com/go-openapi/spec/issues/23 for more context
+	sm.ID = ""
 
 	// update model builder with completed model
 	b.Definitions[modelName] = sm

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -1,7 +1,9 @@
 package restfulspec
 
 import "testing"
-import "github.com/go-openapi/spec"
+import (
+	"github.com/go-openapi/spec"
+)
 
 type Apple struct {
 	Species string
@@ -20,6 +22,9 @@ func TestAppleDef(t *testing.T) {
 		t.Errorf("got %v want %v", got, want)
 	}
 	if got, want := schema.Required[1], "vol"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := schema.ID, ""; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 }

--- a/examples/openapi.json
+++ b/examples/openapi.json
@@ -1,0 +1,233 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Resource for managing Users",
+    "title": "UserService",
+    "contact": {
+      "name": "john",
+      "url": "http://johndoe.org",
+      "email": "john@doe.rp"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://mit.org"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "description": "get all users",
+        "consumes": [
+          "application/xml",
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "get all users",
+        "operationId": "findAllUsers",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/main.User"
+              }
+            }
+          },
+          "default": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/main.User"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "create a user",
+        "consumes": [
+          "application/xml",
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "create a user",
+        "operationId": "createUser",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/users/{user-id}": {
+      "get": {
+        "description": "get a user",
+        "consumes": [
+          "application/xml",
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "get a user",
+        "operationId": "findUser",
+        "parameters": [
+          {
+            "type": "integer",
+            "default": 1,
+            "description": "identifier of the user",
+            "name": "user-id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "default": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "update a user",
+        "consumes": [
+          "application/xml",
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "update a user",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "identifier of the user",
+            "name": "user-id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "description": "delete a user",
+        "consumes": [
+          "application/xml",
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "tags": [
+          "users"
+        ],
+        "summary": "delete a user",
+        "operationId": "removeUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "identifier of the user",
+            "name": "user-id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "main.User": {
+      "required": [
+        "id",
+        "name",
+        "age"
+      ],
+      "properties": {
+        "age": {
+          "description": "age of the user",
+          "type": "integer",
+          "format": "int32",
+          "default": 21
+        },
+        "id": {
+          "description": "identifier of the user",
+          "type": "string"
+        },
+        "name": {
+          "description": "name of the user",
+          "type": "string",
+          "default": "john"
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Managing users",
+      "name": "users"
+    }
+  ]
+}

--- a/examples/user-resource_test.go
+++ b/examples/user-resource_test.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"testing"
-	"io/ioutil"
-	"github.com/emicklei/go-restful-openapi"
-	"github.com/emicklei/go-restful"
-	spec2 "github.com/go-openapi/spec"
 	"encoding/json"
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful-openapi"
+	spec2 "github.com/go-openapi/spec"
+	"io/ioutil"
 	"reflect"
+	"testing"
 )
 
 func TestAppleDef(t *testing.T) {
@@ -17,10 +17,7 @@ func TestAppleDef(t *testing.T) {
 		t.Error("Loading the openapi specification failed.")
 	}
 	ws := UserResource{}.WebService()
-	expected := &spec2.Swagger{}
-	if err := json.Unmarshal(raw, expected); err != nil {
-		t.Error("Unmarshaling the openapi specification failed.")
-	}
+	expected := asStruct(string(raw))
 
 	config := restfulspec.Config{
 		WebServices:    []*restful.WebService{ws}, // you control what services are visible
@@ -30,7 +27,7 @@ func TestAppleDef(t *testing.T) {
 
 	actual := restfulspec.BuildSwagger(config)
 
-	if reflect.DeepEqual(expected, actual) != true {
+	if reflect.DeepEqual(expected, asStruct(asJSON(actual))) != true {
 		t.Errorf("Got:\n%v\nWanted:\n%v", asJSON(actual), asJSON(expected))
 	}
 }
@@ -40,3 +37,8 @@ func asJSON(v interface{}) string {
 	return string(data)
 }
 
+func asStruct(raw string) *spec2.Swagger {
+	expected := &spec2.Swagger{}
+	json.Unmarshal([]byte(raw), expected)
+	return expected
+}

--- a/examples/user-resource_test.go
+++ b/examples/user-resource_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+	"io/ioutil"
+	"github.com/emicklei/go-restful-openapi"
+	"github.com/emicklei/go-restful"
+	spec2 "github.com/go-openapi/spec"
+	"encoding/json"
+	"reflect"
+)
+
+func TestAppleDef(t *testing.T) {
+
+	raw, err := ioutil.ReadFile("./openapi.json")
+	if err != nil {
+		t.Error("Loading the openapi specification failed.")
+	}
+	ws := UserResource{}.WebService()
+	expected := &spec2.Swagger{}
+	if err := json.Unmarshal(raw, expected); err != nil {
+		t.Error("Unmarshaling the openapi specification failed.")
+	}
+
+	config := restfulspec.Config{
+		WebServices:    []*restful.WebService{ws}, // you control what services are visible
+		WebServicesURL: "http://localhost:8080",
+		APIPath:        "/apidocs.json",
+		PostBuildSwaggerObjectHandler: enrichSwaggerObject}
+
+	actual := restfulspec.BuildSwagger(config)
+
+	if reflect.DeepEqual(expected, actual) != true {
+		t.Errorf("Got:\n%v\nWanted:\n%v", asJSON(actual), asJSON(expected))
+	}
+}
+
+func asJSON(v interface{}) string {
+	data, _ := json.MarshalIndent(v, " ", " ")
+	return string(data)
+}
+


### PR DESCRIPTION
Arrays now reference the properr model definition and SchemaProps.ID is now always empty, to avoid serialization, since it conflicts with the openapi specification.

Fixes #26 