### PR TITLE
display "Notes" instead of "Doc" in description

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -74,7 +74,7 @@ func buildPathItem(ws *restful.WebService, r restful.Route, existingPathItem spe
 
 func buildOperation(ws *restful.WebService, r restful.Route, patterns map[string]string, cfg Config) *spec.Operation {
 	o := spec.NewOperation(r.Operation)
-	o.Description = r.Doc
+	o.Description = r.Notes
 	// take the first line (stripping HTML tags) to be the summary
 	if lines := strings.Split(r.Doc, "\n"); len(lines) > 0 {
 		o.Summary = stripTags(lines[0])

--- a/build_path.go
+++ b/build_path.go
@@ -75,10 +75,7 @@ func buildPathItem(ws *restful.WebService, r restful.Route, existingPathItem spe
 func buildOperation(ws *restful.WebService, r restful.Route, patterns map[string]string, cfg Config) *spec.Operation {
 	o := spec.NewOperation(r.Operation)
 	o.Description = r.Notes
-	// take the first line (stripping HTML tags) to be the summary
-	if lines := strings.Split(r.Doc, "\n"); len(lines) > 0 {
-		o.Summary = stripTags(lines[0])
-	}
+	o.Summary = stripTags(r.Doc)
 	o.Consumes = r.Consumes
 	o.Produces = r.Produces
 	o.Deprecated = r.Deprecated

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -24,7 +24,6 @@ func TestRouteToPath(t *testing.T) {
 		Returns(200, "list of a b tests", []Sample{}).
 		Writes([]Sample{}))
 	ws.Route(ws.GET("/a/{b}/{c:[a-z]+}/{d:[1-9]+}/e").To(dummy).
-		Doc("get the a b test").
 		Param(ws.PathParameter("b", "value of b").DefaultValue("default-b")).
 		Param(ws.PathParameter("c", "with regex").DefaultValue("abc")).
 		Param(ws.PathParameter("d", "with regex").DefaultValue("abcef")).
@@ -45,7 +44,7 @@ func TestRouteToPath(t *testing.T) {
 	if p.Paths["/tests/{v}/a/{b}"].Get.Description != notes {
 		t.Errorf("GET description incorrect")
 	}
-	if p.Paths["/tests/{v}/a/{b}"].Get.Summary != "get the a b test" {
+	if p.Paths["/tests/{v}/a/{b}"].Get.Summary != "get the a b test\nthis is the test description" {
 		t.Errorf("GET summary incorrect")
 	}
 	response := p.Paths["/tests/{v}/a/{b}"].Get.Responses.StatusCodeResponses[200]

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestRouteToPath(t *testing.T) {
 	description := "get the <strong>a</strong> <em>b</em> test\nthis is the test description"
+	notes := "notes\nblah blah"
 
 	ws := new(restful.WebService)
 	ws.Path("/tests/{v}")
@@ -17,6 +18,7 @@ func TestRouteToPath(t *testing.T) {
 	ws.Produces(restful.MIME_XML)
 	ws.Route(ws.GET("/a/{b}").To(dummy).
 		Doc(description).
+		Notes(notes).
 		Param(ws.PathParameter("b", "value of b").DefaultValue("default-b")).
 		Param(ws.QueryParameter("q", "value of q").DefaultValue("default-q")).
 		Returns(200, "list of a b tests", []Sample{}).
@@ -40,7 +42,7 @@ func TestRouteToPath(t *testing.T) {
 		t.Error("Expected path to exist after it was sanitized.")
 	}
 
-	if p.Paths["/tests/{v}/a/{b}"].Get.Description != description {
+	if p.Paths["/tests/{v}/a/{b}"].Get.Description != notes {
 		t.Errorf("GET description incorrect")
 	}
 	if p.Paths["/tests/{v}/a/{b}"].Get.Summary != "get the a b test" {
@@ -99,11 +101,11 @@ func TestMultipleMethodsRouteToPath(t *testing.T) {
 	p := buildPaths(ws, Config{})
 	t.Log(asJSON(p))
 
-	if p.Paths["/tests/a/a/b"].Get.Description != "get a b test" {
-		t.Errorf("GET description incorrect")
+	if p.Paths["/tests/a/a/b"].Get.Summary != "get a b test" {
+		t.Errorf("GET summary incorrect")
 	}
-	if p.Paths["/tests/a/a/b"].Post.Description != "post a b test" {
-		t.Errorf("POST description incorrect")
+	if p.Paths["/tests/a/a/b"].Post.Summary != "post a b test" {
+		t.Errorf("POST summary incorrect")
 	}
 	if _, exists := p.Paths["/tests/a/a/b"].Post.Responses.StatusCodeResponses[500]; !exists {
 		t.Errorf("Response code 500 not added to spec.")

--- a/examples/openapi.json
+++ b/examples/openapi.json
@@ -17,7 +17,6 @@
   "paths": {
     "/users": {
       "get": {
-        "description": "get all users",
         "consumes": [
           "application/xml",
           "application/json"
@@ -53,7 +52,6 @@
         }
       },
       "put": {
-        "description": "create a user",
         "consumes": [
           "application/xml",
           "application/json"
@@ -86,7 +84,6 @@
     },
     "/users/{user-id}": {
       "get": {
-        "description": "get a user",
         "consumes": [
           "application/xml",
           "application/json"
@@ -129,7 +126,6 @@
         }
       },
       "put": {
-        "description": "update a user",
         "consumes": [
           "application/xml",
           "application/json"
@@ -167,7 +163,6 @@
         }
       },
       "delete": {
-        "description": "delete a user",
         "consumes": [
           "application/xml",
           "application/json"


### PR DESCRIPTION
This is to stay consistent with the swagger 1.2 implementation and the
way go-restful was originally designed. It also allows you to have
separate summary vs description instead of duplicating the first line
of the description as a summary.

fix #35

By the way, I do understand that this might be a breaking change for existing users of swagger 2.0, so please consider this carefully. I still think it's worth making this change despite the potential to break things for some users because it this behaviour DID break Notes for us when upgrading from swagger 1.2 to 2.0.