### PR TITLE
Allow operations to return primitive types

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -199,7 +199,14 @@ func buildResponse(e restful.ResponseError, cfg Config) (r spec.Response) {
 			}
 		} else {
 			modelName := definitionBuilder{}.keyFrom(st)
-			r.Schema.Ref = spec.MustCreateRef("#/definitions/" + modelName)
+			if isPrimitiveType(modelName) {
+				// If the response is a primitive type, then don't reference any definitions.
+				// Instead, set the schema's "type" to the model name.
+				r.Schema.AddType(modelName, "")
+			} else {
+				modelName := definitionBuilder{}.keyFrom(st)
+				r.Schema.Ref = spec.MustCreateRef("#/definitions/" + modelName)
+			}
 		}
 	}
 	return r


### PR DESCRIPTION
Before this change, if an operation returned a primitive type, then this would create a "ref" to it (which would never exist, because it was a primitive type).

For example, if you returned a string, then you would get back a "ref" of `#/definitions/string`, which is bad.  Now, the ref will not be set, and the "type" will be set to "string" properly.