### PR TITLE
Add support for map types using "additional properties"

### DIFF
--- a/definition_builder.go
+++ b/definition_builder.go
@@ -196,9 +196,7 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 		prop.Type = []string{stringt}
 		return jsonName, modelDescription, prop
 	case fieldKind == reflect.Map:
-		// if it's a map, it's unstructured, and swagger can't handle it
-		objectType := "object"
-		prop.Type = []string{objectType}
+		jsonName, prop := b.buildMapTypeProperty(field, jsonName, modelName)
 		return jsonName, modelDescription, prop
 	}
 
@@ -311,6 +309,38 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	}
 	if !isPrimitive {
 		b.addModel(fieldType.Elem(), elemTypeName)
+	}
+	return jsonName, prop
+}
+
+func (b definitionBuilder) buildMapTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
+	setPropertyMetadata(&prop, field)
+	fieldType := field.Type
+	var pType = "object"
+	prop.Type = []string{pType}
+
+	// As long as the element isn't an interface, we should be able to figure out what the
+	// intended type is and represent it in `AdditionalProperties`.
+	// See: https://swagger.io/docs/specification/data-models/dictionaries/
+	if fieldType.Elem().Kind().String() != "interface" {
+		isPrimitive := b.isPrimitiveType(fieldType.Elem().Name())
+		elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
+		prop.AdditionalProperties = &spec.SchemaOrBool{
+			Schema: &spec.Schema{},
+		}
+		if isPrimitive {
+			mapped := b.jsonSchemaType(elemTypeName)
+			prop.AdditionalProperties.Schema.Type = []string{mapped}
+		} else {
+			prop.AdditionalProperties.Schema.Ref = spec.MustCreateRef("#/definitions/" + elemTypeName)
+		}
+		// add|overwrite model for element type
+		if fieldType.Elem().Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		if !isPrimitive {
+			b.addModel(fieldType.Elem(), elemTypeName)
+		}
 	}
 	return jsonName, prop
 }

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -1,7 +1,8 @@
 package restfulspec
 
-import "testing"
 import (
+	"testing"
+
 	"github.com/go-openapi/spec"
 )
 
@@ -13,6 +14,10 @@ type Apple struct {
 func TestAppleDef(t *testing.T) {
 	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
 	db.addModelFrom(Apple{})
+
+	if got, want := len(db.Definitions), 1; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
 
 	schema := db.Definitions["restfulspec.Apple"]
 	if got, want := len(schema.Required), 2; got != want {
@@ -26,5 +31,150 @@ func TestAppleDef(t *testing.T) {
 	}
 	if got, want := schema.ID, ""; got != want {
 		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+type MyDictionaryResponse struct {
+	Dictionary1 map[string]DictionaryValue `json:"dictionary1"`
+	Dictionary2 map[string]interface{}     `json:"dictionary2"`
+}
+type DictionaryValue struct {
+	Key1 string `json:"key1"`
+	Key2 string `json:"key2"`
+}
+
+func TestDictionarySupport(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
+	db.addModelFrom(MyDictionaryResponse{})
+
+	// Make sure that only the types that we want were created.
+	if got, want := len(db.Definitions), 2; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+
+	schema, schemaFound := db.Definitions["restfulspec.MyDictionaryResponse"]
+	if !schemaFound {
+		t.Errorf("could not find schema")
+	} else {
+		if got, want := len(schema.Required), 2; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if got, want := schema.Required[0], "dictionary1"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+			if got, want := schema.Required[1], "dictionary2"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+		}
+		if got, want := len(schema.Properties), 2; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if property, found := schema.Properties["dictionary1"]; !found {
+				t.Errorf("could not find property")
+			} else {
+				if got, want := property.AdditionalProperties.Schema.SchemaProps.Ref.String(), "#/definitions/restfulspec.DictionaryValue"; got != want {
+					t.Errorf("got %v want %v", got, want)
+				}
+			}
+			if property, found := schema.Properties["dictionary2"]; !found {
+				t.Errorf("could not find property")
+			} else {
+				if property.AdditionalProperties != nil {
+					t.Errorf("unexpected additional properties")
+				}
+			}
+		}
+	}
+
+	schema, schemaFound = db.Definitions["restfulspec.DictionaryValue"]
+	if !schemaFound {
+		t.Errorf("could not find schema")
+	} else {
+		if got, want := len(schema.Required), 2; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if got, want := schema.Required[0], "key1"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+			if got, want := schema.Required[1], "key2"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+		}
+	}
+}
+
+type MyRecursiveDictionaryResponse struct {
+	Dictionary1 map[string]RecursiveDictionaryValue `json:"dictionary1"`
+}
+type RecursiveDictionaryValue struct {
+	Key1 string                              `json:"key1"`
+	Key2 map[string]RecursiveDictionaryValue `json:"key2"`
+}
+
+func TestRecursiveDictionarySupport(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
+	db.addModelFrom(MyRecursiveDictionaryResponse{})
+
+	// Make sure that only the types that we want were created.
+	if got, want := len(db.Definitions), 2; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+
+	schema, schemaFound := db.Definitions["restfulspec.MyRecursiveDictionaryResponse"]
+	if !schemaFound {
+		t.Errorf("could not find schema")
+	} else {
+		if got, want := len(schema.Required), 1; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if got, want := schema.Required[0], "dictionary1"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+		}
+		if got, want := len(schema.Properties), 1; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if property, found := schema.Properties["dictionary1"]; !found {
+				t.Errorf("could not find property")
+			} else {
+				if got, want := property.AdditionalProperties.Schema.SchemaProps.Ref.String(), "#/definitions/restfulspec.RecursiveDictionaryValue"; got != want {
+					t.Errorf("got %v want %v", got, want)
+				}
+			}
+		}
+	}
+
+	schema, schemaFound = db.Definitions["restfulspec.RecursiveDictionaryValue"]
+	if !schemaFound {
+		t.Errorf("could not find schema")
+	} else {
+		if got, want := len(schema.Required), 2; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if got, want := schema.Required[0], "key1"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+			if got, want := schema.Required[1], "key2"; got != want {
+				t.Errorf("got %v want %v", got, want)
+			}
+		}
+		if got, want := len(schema.Properties), 2; got != want {
+			t.Errorf("got %v want %v", got, want)
+		} else {
+			if property, found := schema.Properties["key1"]; !found {
+				t.Errorf("could not find property")
+			} else {
+				if property.AdditionalProperties != nil {
+					t.Errorf("unexpected additional properties")
+				}
+			}
+			if property, found := schema.Properties["key2"]; !found {
+				t.Errorf("could not find property")
+			} else {
+				if got, want := property.AdditionalProperties.Schema.SchemaProps.Ref.String(), "#/definitions/restfulspec.RecursiveDictionaryValue"; got != want {
+					t.Errorf("got %v want %v", got, want)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
According to https://swagger.io/docs/specification/data-models/dictionaries/, we can use a model's "additional properties" to create a functional map structure.

This commit basically copies the array workflow and does something similar for objects.  If the type of the map cannot be determined (for example, if it is `map[string]interface{}`), then this will just define an empty object with no additional properties, just like it used to work prior to this change.