### PR TITLE
prevent array param.Type be overwritten in the else case below

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -129,14 +129,6 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, pattern st
 	p := spec.Parameter{}
 	param := restfulParam.Data()
 	p.In = asParamType(param.Kind)
-	if param.AllowMultiple {
-		p.Type = "array"
-		p.Items = spec.NewItems()
-		p.Items.Type = param.DataType
-		p.CollectionFormat = param.CollectionFormat
-	} else {
-		p.Type = param.DataType
-	}
 	p.Description = param.Description
 	p.Name = param.Name
 	p.Required = param.Required
@@ -166,7 +158,14 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, pattern st
 		}
 
 	} else {
-		p.Type = param.DataType
+		if param.AllowMultiple {
+			p.Type = "array"
+			p.Items = spec.NewItems()
+			p.Items.Type = param.DataType
+			p.CollectionFormat = param.CollectionFormat
+		} else {
+			p.Type = param.DataType
+		}
 		p.Default = stringAutoType(param.DefaultValue)
 		p.Format = param.DataFormat
 	}

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -27,7 +27,8 @@ func TestRouteToPath(t *testing.T) {
 		Param(ws.PathParameter("b", "value of b").DefaultValue("default-b")).
 		Param(ws.PathParameter("c", "with regex").DefaultValue("abc")).
 		Param(ws.PathParameter("d", "with regex").DefaultValue("abcef")).
-		Param(ws.QueryParameter("q", "value of q").DefaultValue("default-q")).
+		Param(ws.QueryParameter("q", "value of q").DataType("string").DataFormat("date").
+			DefaultValue("default-q").AllowMultiple(true)).
 		Returns(200, "list of a b tests", []Sample{}).
 		Writes([]Sample{}))
 
@@ -39,6 +40,14 @@ func TestRouteToPath(t *testing.T) {
 	}
 	if _, exists := p.Paths["/tests/{v}/a/{b}/{c}/{d}/e"]; !exists {
 		t.Error("Expected path to exist after it was sanitized.")
+	}
+
+	q, exists := getParameter(p.Paths["/tests/{v}/a/{b}/{c}/{d}/e"], "q")
+	if !exists {
+		t.Errorf("get parameter q failed")
+	}
+	if q.Type != "array" || q.Items.Type != "string" || q.Format != "date" {
+		t.Errorf("parameter q expected to be a date array")
 	}
 
 	if p.Paths["/tests/{v}/a/{b}"].Get.Description != notes {


### PR DESCRIPTION
In the else case, it would overwrite p.Type and makes AllowMultiple not work.