### PR TITLE
Merge paths with existing paths from other webServices

### DIFF
--- a/spec_resource.go
+++ b/spec_resource.go
@@ -30,6 +30,13 @@ func BuildSwagger(config Config) *spec.Swagger {
 
 	for _, each := range config.WebServices {
 		for path, item := range buildPaths(each, config).Paths {
+			existingPathItem, ok := paths.Paths[path]
+			if ok {
+				for _, r := range each.Routes() {
+					_, patterns := sanitizePath(r.Path)
+					item = buildPathItem(each, r, existingPathItem, patterns, config)
+				}
+			}
 			paths.Paths[path] = item
 		}
 		for name, def := range buildDefinitions(each, config) {

--- a/spec_resource_test.go
+++ b/spec_resource_test.go
@@ -1,0 +1,28 @@
+package restfulspec
+
+import (
+	"testing"
+
+	restful "github.com/emicklei/go-restful"
+)
+
+func TestBuildSwagger(t *testing.T) {
+	path := "/testPath"
+
+	ws1 := new(restful.WebService)
+	ws1.Path(path)
+	ws1.Route(ws1.GET("").To(dummy))
+
+	ws2 := new(restful.WebService)
+	ws2.Path(path)
+	ws2.Route(ws2.DELETE("").To(dummy))
+
+	c := Config{}
+	c.WebServices = []*restful.WebService{ws1, ws2}
+	s := BuildSwagger(c)
+
+	if !(s.Paths.Paths[path].Get != nil && s.Paths.Paths[path].Delete != nil) {
+		t.Errorf("Swagger spec should have methods for GET and DELETE")
+	}
+
+}


### PR DESCRIPTION
If you have the same path (but different HTTP methods) defined on different web services, the first one is overwritten when BuildSwagger is called. This PR allows the paths and operations to be merged.