### PR TITLE
Change Sirupsen/logrus to sirupsen/logrus

### DIFF
--- a/examples/security/api.go
+++ b/examples/security/api.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	restful "github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 )


### PR DESCRIPTION
... as `sirupsen/logrus` is now the recommended way to vendor and import this library.
As per the project's [`README.md`](https://github.com/sirupsen/logrus/blob/master/README.md):
> For an in-depth explanation of the casing issue, see [this comment](https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276).
