### PR TITLE
Added support for 'time.Duration' type in definition_builder and build_path

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -230,7 +230,7 @@ func isPrimitiveType(modelName string) bool {
 	if len(modelName) == 0 {
 		return false
 	}
-	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time", modelName)
+	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time time.Duration", modelName)
 }
 
 func jsonSchemaType(modelName string) string {
@@ -252,6 +252,7 @@ func jsonSchemaType(modelName string) string {
 		"float32":   "number",
 		"bool":      "boolean",
 		"time.Time": "string",
+		"time.Duration": "integer",
 	}
 	mapped, ok := schemaMap[modelName]
 	if !ok {

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -421,7 +421,7 @@ func (b definitionBuilder) isPrimitiveType(modelName string) bool {
 	if len(modelName) == 0 {
 		return false
 	}
-	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time", modelName)
+	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time time.Duration", modelName)
 }
 
 // jsonNameOfField returns the name of the field as it should appear in JSON format
@@ -459,6 +459,7 @@ func (b definitionBuilder) jsonSchemaType(modelName string) string {
 		"float32":   "number",
 		"bool":      "boolean",
 		"time.Time": "string",
+		"time.Duration": "integer",
 	}
 	mapped, ok := schemaMap[modelName]
 	if !ok {
@@ -484,6 +485,8 @@ func (b definitionBuilder) jsonSchemaFormat(modelName string) string {
 		"float32":    "float",
 		"time.Time":  "date-time",
 		"*time.Time": "date-time",
+		"time.Duration": "integer",
+		"*time.Duration": "integer",
 	}
 	mapped, ok := schemaMap[modelName]
 	if !ok {


### PR DESCRIPTION
This pull request is to fix issue: https://github.com/emicklei/go-restful-openapi/issues/55