### PR TITLE
support data format for structs

### DIFF
--- a/property_ext.go
+++ b/property_ext.go
@@ -32,6 +32,13 @@ func setEnumValues(prop *spec.Schema, field reflect.StructField) {
 	}
 }
 
+func setFormat(prop *spec.Schema, field reflect.StructField) {
+	if tag := field.Tag.Get("format"); tag != "" {
+		prop.Format = tag
+	}
+
+}
+
 func setMaximum(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("maximum"); tag != "" {
 		value, err := strconv.ParseFloat(tag, 64)
@@ -96,6 +103,7 @@ func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setDescription(prop, field)
 	setDefaultValue(prop, field)
 	setEnumValues(prop, field)
+	setFormat(prop, field)
 	setMinimum(prop, field)
 	setMaximum(prop, field)
 	setUniqueItems(prop, field)

--- a/property_ext_test.go
+++ b/property_ext_test.go
@@ -21,6 +21,7 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 		Password  string
 		Optional  bool   `optional:"true"`
 		Created   string `readOnly:"true"`
+		UUID      string `type:"string" format:"UUID"`
 	}
 	d := definitionsFromStruct(Anything{})
 	props, _ := d["restfulspec.Anything"]
@@ -80,6 +81,13 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 		t.Errorf("got %v want %v", got, want)
 	}
 	if got, want := props.Description, "a test\nmore description"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p10, _ := props.Properties["UUID"]
+	if got, want := p10.Type[0], "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := p10.Format, "UUID"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 }


### PR DESCRIPTION
Declaring only the type might be sometimes ambiguous. For example, an
UUID will typically be serialized as a string, but just declarding it as
such might be unnecessarily ambiguous for an API user.

Using the builder API, it is already possible to declare a format for
path parameters (with `DataFormat()`), but for structs there was no
corresponding tag so far.

See https://swagger.io/specification/v2/#dataTypeFormat
