### PR TITLE
support data format for structs (#72) for v2

### DIFF
--- a/property_ext.go
+++ b/property_ext.go
@@ -44,6 +44,13 @@ func setEnumValues(prop *spec.Schema, field reflect.StructField) {
 	}
 }
 
+func setFormat(prop *spec.Schema, field reflect.StructField) {
+	if tag := field.Tag.Get("format"); tag != "" {
+		prop.Format = tag
+	}
+
+}
+
 func setMaximum(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("maximum"); tag != "" {
 		value, err := strconv.ParseFloat(tag, 64)
@@ -108,6 +115,7 @@ func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setDescription(prop, field)
 	setDefaultValue(prop, field)
 	setEnumValues(prop, field)
+	setFormat(prop, field)
 	setMinimum(prop, field)
 	setMaximum(prop, field)
 	setUniqueItems(prop, field)

--- a/property_ext_test.go
+++ b/property_ext_test.go
@@ -24,6 +24,7 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 		Created          string `readOnly:"true"`
 		NullableField    string `x-nullable:"true"`
 		NotNullableField string `x-nullable:"false"`
+		UUID             string `type:"string" format:"UUID"`
 	}
 	d := definitionsFromStruct(Anything{})
 	props, _ := d["restfulspec.Anything"]
@@ -91,6 +92,13 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 	}
 	p11, _ := props.Properties["NotNullableField"]
 	if got, want := p11.Extensions["x-nullable"], false; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p12, _ := props.Properties["UUID"]
+	if got, want := p12.Type[0], "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := p12.Format, "UUID"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 }


### PR DESCRIPTION
Declaring only the type might be sometimes ambiguous. For example, an
UUID will typically be serialized as a string, but just declarding it as
such might be unnecessarily ambiguous for an API user.

Using the builder API, it is already possible to declare a format for
path parameters (with `DataFormat()`), but for structs there was no
corresponding tag so far.

See https://swagger.io/specification/v2/#dataTypeFormat