### PR TITLE
Use int64 format for time.Duration type

### DIFF
--- a/definition_builder.go
+++ b/definition_builder.go
@@ -539,8 +539,8 @@ func (b definitionBuilder) jsonSchemaFormat(modelName string, modelKind reflect.
 	schemaMap := map[string]string{
 		"time.Time":      "date-time",
 		"*time.Time":     "date-time",
-		"time.Duration":  "integer",
-		"*time.Duration": "integer",
+		"time.Duration":  "int64",
+		"*time.Duration": "int64",
 		"json.Number":    "double",
 		"*json.Number":   "double",
 	}


### PR DESCRIPTION
The time.Duration based on int64, so it would be better to use int64 for format