### PR TITLE
Add missing fields of response header object

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -305,9 +305,12 @@ func buildHeader(header restful.Header) spec.Header {
 	responseHeader := spec.Header{}
 	responseHeader.Type = header.Type
 	responseHeader.Description = header.Description
+	responseHeader.Format = header.Format
+	responseHeader.Default = header.Default
 
 	// If type is "array" items field is required
 	if header.Type == arrayType {
+		responseHeader.CollectionFormat = header.CollectionFormat
 		responseHeader.Items = buildHeadersItems(header.Items)
 	}
 


### PR DESCRIPTION
According to the documentation https://swagger.io/specification/v2/#headerObject,
every header obejct has same fields like its items.

Added the `format`, `default` and `collectionFormat` fields.