### PR TITLE
Add property x-go-name support

### DIFF
--- a/property_ext.go
+++ b/property_ext.go
@@ -8,6 +8,12 @@ import (
 	"github.com/go-openapi/spec"
 )
 
+func initPropExtensions(ext *spec.Extensions) {
+	if *ext == nil {
+		*ext = make(spec.Extensions, 0)
+	}
+}
+
 func setDescription(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("description"); tag != "" {
 		prop.Description = tag
@@ -22,13 +28,19 @@ func setDefaultValue(prop *spec.Schema, field reflect.StructField) {
 
 func setIsNullableValue(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("x-nullable"); tag != "" {
-		if prop.Extensions == nil {
-			prop.Extensions = make(spec.Extensions, 0)
-		}
+		initPropExtensions(&prop.Extensions)
 
 		value, err := strconv.ParseBool(tag)
 
 		prop.Extensions["x-nullable"] = value && err == nil
+	}
+}
+
+func setGoNameValue(prop *spec.Schema, field reflect.StructField) {
+	const tagName = "x-go-name"
+	if tag := field.Tag.Get(tagName); tag != "" {
+		initPropExtensions(&prop.Extensions)
+		prop.Extensions[tagName] = tag
 	}
 }
 
@@ -122,4 +134,5 @@ func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setType(prop, field)
 	setReadOnly(prop, field)
 	setIsNullableValue(prop, field)
+	setGoNameValue(prop, field)
 }

--- a/property_ext_test.go
+++ b/property_ext_test.go
@@ -25,6 +25,7 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 		NullableField    string `x-nullable:"true"`
 		NotNullableField string `x-nullable:"false"`
 		UUID             string `type:"string" format:"UUID"`
+		XGoName          string `x-go-name:"specgoname"`
 	}
 	d := definitionsFromStruct(Anything{})
 	props, _ := d["restfulspec.Anything"]
@@ -99,6 +100,10 @@ func TestThatExtraTagsAreReadIntoModel(t *testing.T) {
 		t.Errorf("got %v want %v", got, want)
 	}
 	if got, want := p12.Format, "UUID"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	p13, _ := props.Properties["XGoName"]
+	if got, want := p13.Extensions["x-go-name"], "specgoname"; got != want {
 		t.Errorf("got %v want %v", got, want)
 	}
 }


### PR DESCRIPTION
`x-go-name` allow [go-swagger](https://github.com/go-swagger/go-swagger) generate spec for the sepcial go name of a type

```go
type UIParameter struct {
	Validate    *Validate `json:"validate,omitempty" x-go-name:"ParamValidate"`
}
```

or 

```go
type DeployTo struct {
	LegacyRuntimeCluster bool `json:"runtime_cluster" x-go-name:"LegacyRuntimeCluster"`
	RuntimeCluster       bool `json:"runtimeCluster" x-go-name:"RuntimeCluster"`
}
```

It is especially useful in certain scenarios.

Signed-off-by: Zhiyu Wang <zhiyuwang.newbis@gmail.com>