### PR TITLE
set allowedvalues and defaultvalue according to data type (#110)

### DIFF
--- a/property_ext.go
+++ b/property_ext.go
@@ -16,7 +16,7 @@ func setDescription(prop *spec.Schema, field reflect.StructField) {
 
 func setDefaultValue(prop *spec.Schema, field reflect.StructField) {
 	if tag := field.Tag.Get("default"); tag != "" {
-		prop.Default = stringAutoType(tag)
+		prop.Default = stringAutoType("", tag)
 	}
 }
 


### PR DESCRIPTION
This ensures that AllowableValues and Default always attempt to parse according to their data type. If no data type is specified or the parse failed, it just sets it as a string as it was doing previously