### PR TITLE
feat: Add type SchemaType to use in Return calls allowing for specification of a raw type value

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -14,6 +14,11 @@ import (
 // KeyOpenAPITags is a Metadata key for a restful Route
 const KeyOpenAPITags = "openapi.tags"
 
+// SchemaType is used to wrap any raw types
+// For example, to return a "schema": "file" one can use
+// Returns(http.StatusOK, http.StatusText(http.StatusOK), SchemaType("file"))
+type SchemaType string
+
 func buildPaths(ws *restful.WebService, cfg Config) spec.Paths {
 	p := spec.Paths{Paths: map[string]spec.PathItem{}}
 	for _, each := range ws.Routes() {
@@ -218,8 +223,9 @@ func buildResponse(e restful.ResponseError, cfg Config) (r spec.Response) {
 				// If the response is a primitive type, then don't reference any definitions.
 				// Instead, set the schema's "type" to the model name.
 				r.Schema.AddType(modelName, "")
+			} else if schemaType, ok := e.Model.(SchemaType); ok {
+				r.Schema.AddType(string(schemaType), "")
 			} else {
-				modelName := keyFrom(st, cfg)
 				r.Schema.Ref = spec.MustCreateRef("#/definitions/" + modelName)
 			}
 		}

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -331,3 +331,44 @@ func TestWritesPrimitive(t *testing.T) {
 		}
 	}
 }
+
+// TestWritesRawSchema ensures that if an operation returns a raw schema value, then it
+// is used as such (and not a ref to a definition).
+func TestWritesRawSchema(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/tests/returns")
+	ws.Consumes(restful.MIME_JSON)
+	ws.Produces(restful.MIME_JSON)
+
+	ws.Route(ws.GET("/raw").To(dummy).
+		Doc("get that returns a file").
+		Returns(200, "raw schema type", SchemaType("file")).
+		Writes(SchemaType("file")))
+
+	p := buildPaths(ws, Config{})
+	t.Log(asJSON(p))
+
+	// Make sure that the operation that returns a raw schema type is correct.
+	if pathInfo, okay := p.Paths["/tests/returns/raw"]; !okay {
+		t.Errorf("Could not find path")
+	} else {
+		getInfo := pathInfo.Get
+
+		if getInfo == nil {
+			t.Errorf("operation was not present")
+		}
+		if getInfo.Summary != "get that returns a file" {
+			t.Errorf("GET description incorrect")
+		}
+		response := getInfo.Responses.StatusCodeResponses[200]
+		if response.Schema.Ref.String() != "" {
+			t.Errorf("Expected no ref; got: %s", response.Schema.Ref.String())
+		}
+		if len(response.Schema.Type) != 1 {
+			t.Errorf("Expected exactly one type; got: %d", len(response.Schema.Type))
+		}
+		if response.Schema.Type[0] != "file" {
+			t.Errorf("Expected a type of file; got: %s", response.Schema.Type[0])
+		}
+	}
+}


### PR DESCRIPTION
As suggested in issue #99, introduce a way to allow specifying a raw schema type.  This allows for a response like
```
"responses": {
  "200": {
    "description": "OK",
    "schema": {
       "type": "file"
    }
  },
  ...
```