### PR TITLE
feat: Make SchemaType a struct containing the RawType and Format for more flexibility

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -16,8 +16,11 @@ const KeyOpenAPITags = "openapi.tags"
 
 // SchemaType is used to wrap any raw types
 // For example, to return a "schema": "file" one can use
-// Returns(http.StatusOK, http.StatusText(http.StatusOK), SchemaType("file"))
-type SchemaType string
+// Returns(http.StatusOK, http.StatusText(http.StatusOK), SchemaType{RawType: "file"})
+type SchemaType struct {
+	RawType string
+	Format  string
+}
 
 func buildPaths(ws *restful.WebService, cfg Config) spec.Paths {
 	p := spec.Paths{Paths: map[string]spec.PathItem{}}
@@ -224,7 +227,7 @@ func buildResponse(e restful.ResponseError, cfg Config) (r spec.Response) {
 				// Instead, set the schema's "type" to the model name.
 				r.Schema.AddType(modelName, "")
 			} else if schemaType, ok := e.Model.(SchemaType); ok {
-				r.Schema.AddType(string(schemaType), "")
+				r.Schema.AddType(schemaType.RawType, schemaType.Format)
 			} else {
 				r.Schema.Ref = spec.MustCreateRef("#/definitions/" + modelName)
 			}

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -342,8 +342,8 @@ func TestWritesRawSchema(t *testing.T) {
 
 	ws.Route(ws.GET("/raw").To(dummy).
 		Doc("get that returns a file").
-		Returns(200, "raw schema type", SchemaType("file")).
-		Writes(SchemaType("file")))
+		Returns(200, "raw schema type", SchemaType{RawType: "file"}).
+		Writes(SchemaType{RawType: "file"}))
 
 	p := buildPaths(ws, Config{})
 	t.Log(asJSON(p))
@@ -369,6 +369,50 @@ func TestWritesRawSchema(t *testing.T) {
 		}
 		if response.Schema.Type[0] != "file" {
 			t.Errorf("Expected a type of file; got: %s", response.Schema.Type[0])
+		}
+	}
+}
+
+// TestWritesRawSchemaWithFormat ensures that if an operation returns a raw schema value with the specified format, then it
+// is used as such (and not a ref to a definition).
+func TestWritesRawSchemaWithFormat(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/tests/returns")
+	ws.Consumes(restful.MIME_JSON)
+	ws.Produces(restful.MIME_JSON)
+
+	ws.Route(ws.GET("/raw_formatted").To(dummy).
+		Doc("get that returns a file").
+		Returns(200, "raw schema type", SchemaType{RawType: "string", Format: "binary"}).
+		Writes(SchemaType{RawType: "string", Format: "binary"}))
+
+	p := buildPaths(ws, Config{})
+	t.Log(asJSON(p))
+
+	// Make sure that the operation that returns a raw schema type is correct.
+	if pathInfo, okay := p.Paths["/tests/returns/raw_formatted"]; !okay {
+		t.Errorf("Could not find path")
+	} else {
+		getInfo := pathInfo.Get
+
+		if getInfo == nil {
+			t.Errorf("operation was not present")
+		}
+		if getInfo.Summary != "get that returns a file" {
+			t.Errorf("GET description incorrect")
+		}
+		response := getInfo.Responses.StatusCodeResponses[200]
+		if response.Schema.Ref.String() != "" {
+			t.Errorf("Expected no ref; got: %s", response.Schema.Ref.String())
+		}
+		if len(response.Schema.Type) != 1 {
+			t.Errorf("Expected exactly one type; got: %d", len(response.Schema.Type))
+		}
+		if response.Schema.Type[0] != "string" {
+			t.Errorf("Expected a type of string; got: %s", response.Schema.Type[0])
+		}
+		if response.Schema.Format != "binary" {
+			t.Errorf("Expected a format of binary; got: %s", response.Schema.Format)
 		}
 	}
 }


### PR DESCRIPTION
I noticed another issue that could be handled with a small change.  This update should also provide a solution for #115 by specifying the model as

`SchemaType{RawType: "string", Format: "binary"}`