### PR TITLE
feat: Add type SchemaType to use in Return calls allowing for specification of a raw type value and format

### DIFF
--- a/build_path.go
+++ b/build_path.go
@@ -8,9 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-openapi/spec"
-
 	"github.com/emicklei/go-restful/v3"
+	"github.com/go-openapi/spec"
 )
 
 const (
@@ -23,6 +22,14 @@ const (
 	arrayType      = "array"
 	definitionRoot = "#/definitions/"
 )
+
+// SchemaType is used to wrap any raw types
+// For example, to return a "schema": "file" one can use
+// Returns(http.StatusOK, http.StatusText(http.StatusOK), SchemaType{RawType: "file"})
+type SchemaType struct {
+	RawType string
+	Format  string
+}
 
 func buildPaths(ws *restful.WebService, cfg Config) spec.Paths {
 	p := spec.Paths{Paths: map[string]spec.PathItem{}}
@@ -295,6 +302,8 @@ func buildResponse(e restful.ResponseError, cfg Config) (r spec.Response) {
 				// If the response is a primitive type, then don't reference any definitions.
 				// Instead, set the schema's "type" to the model name.
 				r.Schema.AddType(modelName, "")
+			} else if schemaType, ok := e.Model.(SchemaType); ok {
+				r.Schema.AddType(schemaType.RawType, schemaType.Format)
 			} else {
 				modelName := keyFrom(st, cfg)
 				r.Schema.Ref = spec.MustCreateRef(definitionRoot + modelName)

--- a/build_path.go
+++ b/build_path.go
@@ -251,6 +251,9 @@ func buildParameter(r restful.Route, restfulParam *restful.Parameter, pattern st
 			} else {
 				p.Schema.Items.Schema.Ref = spec.MustCreateRef(definitionRoot + dataTypeName)
 			}
+		} else if schemaType, ok := r.ReadSample.(SchemaType); ok {
+			p.Schema.Type = []string{schemaType.RawType}
+			p.Schema.Format = schemaType.Format
 		} else {
 			dataTypeName := keyFrom(st, cfg)
 			p.Schema.Ref = spec.MustCreateRef(definitionRoot + dataTypeName)

--- a/build_path.go
+++ b/build_path.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/emicklei/go-restful/v3"
 	"github.com/go-openapi/spec"
+
+	"github.com/emicklei/go-restful/v3"
 )
 
 const (

--- a/build_path_test.go
+++ b/build_path_test.go
@@ -475,3 +475,70 @@ func TestWritesRawSchemaWithFormat(t *testing.T) {
 		}
 	}
 }
+
+// TestReadAndWriteArrayBytesInBody ensures that if an operation reads []byte in body or returns []byte,
+// then it is represented as "string" with "binary" format.
+func TestReadAndWriteArrayBytesInBody(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/tests/a")
+	ws.Consumes(restful.MIME_JSON)
+	ws.Produces(restful.MIME_XML)
+
+	binaryType := SchemaType{RawType: "string", Format: "binary"}
+	ws.Route(ws.POST("/a/b").To(dummy).
+		Doc("post a b test with array of bytes in body").
+		Returns(200, "list of a b tests", binaryType).
+		Returns(500, "internal server error", binaryType).
+		Reads(binaryType).
+		Writes(binaryType))
+
+	p := buildPaths(ws, Config{})
+	t.Log(asJSON(p))
+
+	postInfo := p.Paths["/tests/a/a/b"].Post
+
+	if postInfo.Summary != "post a b test with array of bytes in body" {
+		t.Errorf("POST description incorrect")
+	}
+	postBody := postInfo.Parameters[0]
+
+	if got, want := postBody.Schema.Type[0], "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := postBody.Schema.Format, "binary"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if postBody.Schema.Ref.String() != "" {
+		t.Errorf("you shouldn't have body Ref setting when using array in body!")
+	}
+	if postBody.Format != "" || postBody.Type != "" || postBody.Default != nil {
+		t.Errorf("Invalid parameter property is set on body property")
+	}
+
+	if _, exists := postInfo.Responses.StatusCodeResponses[200]; !exists {
+		t.Errorf("Response code 200 not added to spec.")
+	}
+	sch := postInfo.Responses.StatusCodeResponses[200].Schema
+	if sch == nil {
+		t.Errorf("Schema for Response code 200 not added to spec.")
+	}
+	if got, want := sch.Type[0], "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := sch.Format, "binary"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if _, exists := postInfo.Responses.StatusCodeResponses[500]; !exists {
+		t.Errorf("Response code 500 not added to spec.")
+	}
+	sch = postInfo.Responses.StatusCodeResponses[500].Schema
+	if sch == nil {
+		t.Errorf("Schema for Response code 500 not added to spec.")
+	}
+	if got, want := sch.Type[0], "string"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+	if got, want := sch.Format, "binary"; got != want {
+		t.Errorf("got %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
As suggested in issue https://github.com/emicklei/go-restful-openapi/issues/99, introduce a way to allow specifying a raw schema type. Using a return model of

`SchemaType{RawType: "file"}` 

results in a schema specification as follows:

```
"responses": {
  "200": {
    "description": "OK",
    "schema": {
       "type": "file"
    }
  },
  ...
```

This should also provide a solution for #115 by specifying the model as

`SchemaType{RawType: "string", Format: "binary"}`

which generates

```
"responses": {
  "200": {
    "description": "raw schema type",
      "schema": {
        "type": "string",
        "format": "binary"
      }
  },
 ...
```