### PR TITLE
fix(enum): make enum field to be located in items object instead of in the root definition object

### DIFF
--- a/definition_builder.go
+++ b/definition_builder.go
@@ -303,7 +303,6 @@ func (b definitionBuilder) buildStructTypeProperty(field reflect.StructField, js
 
 func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
 	setPropertyMetadata(&prop, field)
-
 	fieldType := field.Type
 	if fieldType.Elem().Kind() == reflect.Uint8 {
 		stringt := "string"
@@ -316,7 +315,6 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	itemSchema := &prop
 	itemType := fieldType
 	isArray := b.isSliceOrArrayType(fieldType.Kind())
-
 	for isArray {
 		itemType = itemType.Elem()
 		isArray = b.isSliceOrArrayType(itemType.Kind())
@@ -348,7 +346,6 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	} else {
 		itemSchema.Ref = spec.MustCreateRef("#/definitions/" + elemTypeName)
 	}
-
 	// add|overwrite model for element type
 	if itemType.Kind() == reflect.Ptr {
 		itemType = itemType.Elem()
@@ -356,7 +353,6 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	if !isPrimitive {
 		b.addModel(itemType, elemTypeName)
 	}
-
 	return jsonName, prop
 }
 

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -1,6 +1,8 @@
 package restfulspec
 
 import (
+	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -302,7 +304,14 @@ func (b definitionBuilder) buildStructTypeProperty(field reflect.StructField, js
 }
 
 func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
+	jsonString, _ := json.MarshalIndent(prop, "", " ")
+	fmt.Printf("%s", jsonString)
+
 	setPropertyMetadata(&prop, field)
+
+	jsonString, _ = json.MarshalIndent(prop, "", " ")
+	fmt.Printf("%s", jsonString)
+
 	fieldType := field.Type
 	if fieldType.Elem().Kind() == reflect.Uint8 {
 		stringt := "string"
@@ -346,6 +355,10 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	if !isPrimitive {
 		b.addModel(itemType, elemTypeName)
 	}
+
+	jsonString, _ = json.MarshalIndent(prop, "", " ")
+	fmt.Printf("%s", jsonString)
+
 	return jsonName, prop
 }
 

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -334,7 +334,7 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	elemTypeName := b.getElementTypeName(modelName, jsonName, itemType)
 
 	// If enum exists, move the enum definition from the `type: "array"` definition to `items`.
-	if prop.Enum != nil && prop.Items != nil {
+	if prop.Enum != nil {
 		prop.Items.Schema.Enum = prop.Enum
 		prop.Enum = nil
 	}

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -3,6 +3,7 @@ package restfulspec
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -582,7 +583,7 @@ func TestTimeField(t *testing.T) {
 }
 
 type arrayofEnumsHolder struct {
-	Titles []string `json:"titles" enum:"EMPLOYEEE|MANAGER"`
+	Titles []string `json:"titles" enum:"EMPLOYEE|MANAGER"`
 }
 
 func TestArrayOfEnumsField(t *testing.T) {
@@ -591,10 +592,7 @@ func TestArrayOfEnumsField(t *testing.T) {
 	sc := db.Definitions["restfulspec.arrayofEnumsHolder"]
 	pr := sc.Properties["titles"]
 
-	jsonString, _ := json.MarshalIndent(pr, "", " ")
-
-	fmt.Printf("%s", jsonString)
-	// if got, want := pr.Format, "date-time"; got != want {
-	// 	t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
-	// }
+	if got, want := pr.Items.Schema.Enum, []interface{}{"EMPLOYEE", "MANAGER"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
 }

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -580,3 +580,21 @@ func TestTimeField(t *testing.T) {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
 }
+
+type arrayofEnumsHolder struct {
+	Titles []string `json:"titles" enum:"EMPLOYEEE|MANAGER"`
+}
+
+func TestArrayOfEnumsField(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
+	db.addModelFrom(arrayofEnumsHolder{})
+	sc := db.Definitions["restfulspec.arrayofEnumsHolder"]
+	pr := sc.Properties["titles"]
+
+	jsonString, _ := json.MarshalIndent(pr, "", " ")
+
+	fmt.Printf("%s", jsonString)
+	// if got, want := pr.Format, "date-time"; got != want {
+	// 	t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	// }
+}

--- a/property_ext.go
+++ b/property_ext.go
@@ -52,7 +52,15 @@ func setEnumValues(prop *spec.Schema, field reflect.StructField) {
 		for _, s := range strings.Split(tag, "|") {
 			enums = append(enums, s)
 		}
-		prop.Enum = enums
+
+		kind := field.Type.Kind()
+
+		if kind == reflect.Slice || kind == reflect.Array {
+			prop.Items.Schema.Enum = enums
+		} else {
+			prop.Enum = enums
+		}
+
 	}
 }
 

--- a/property_ext.go
+++ b/property_ext.go
@@ -52,15 +52,7 @@ func setEnumValues(prop *spec.Schema, field reflect.StructField) {
 		for _, s := range strings.Split(tag, "|") {
 			enums = append(enums, s)
 		}
-
-		kind := field.Type.Kind()
-
-		if kind == reflect.Slice || kind == reflect.Array {
-			prop.Items.Schema.Enum = enums
-		} else {
-			prop.Enum = enums
-		}
-
+		prop.Enum = enums
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/emicklei/go-restful-openapi/issues/51. Previously, the output is like this:

```json
{
  "type": "array",
  "enum": ["EMPLOYEE", "MANAGER"],
  "items": {
    "type": "string"
  }
}
```

After this PR:

```json
{
  "type": "array",
  "items": {
    "enum": ["EMPLOYEE", "MANAGER"],
    "type": "string"
  }
}
```

I have also added tests to ensure the behavior is as intended.