### PR TITLE
feat: allow providing example value to a property via "example" tag

### DIFF
--- a/definition_builder.go
+++ b/definition_builder.go
@@ -205,8 +205,7 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 	}
 
 	// not a primitive
-	// Need to re-assign the `example` field, because the `prop` variable is a new one, different than the `prop` variable
-	// from the above lines that we have assigned the `example` field with (via `setPropertyMetadata`).
+	// Since the `prop` variable in each of the cases below is a new reference, we need to re-set the `Example` field.
 	switch {
 	case fieldKind == reflect.Struct:
 		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -205,18 +205,28 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 	}
 
 	// not a primitive
+	// Need to re-assign the `example` field, because the `prop` variable is a new one, different than the `prop` variable
+	// from the above lines that we have assigned the `example` field with (via `setPropertyMetadata`).
 	switch {
 	case fieldKind == reflect.Struct:
 		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case b.isSliceOrArrayType(fieldKind):
 		jsonName, prop := b.buildArrayTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case fieldKind == reflect.Ptr:
 		jsonName, prop := b.buildPointerTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case fieldKind == reflect.Map:
 		jsonName, prop := b.buildMapTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	}
 
@@ -229,6 +239,7 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 		prop.Ref = spec.MustCreateRef("#/definitions/" + nestedTypeName)
 		b.addModel(fieldType, nestedTypeName)
 	}
+
 	return jsonName, modelDescription, prop
 }
 

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -604,16 +604,21 @@ func TestCustomSchemaFormatHandler(t *testing.T) {
 	}}
 	db.addModelFrom(customSchemaFormatHolder{})
 	sc := db.Definitions["restfulspec.customSchemaFormatHolder"]
-	pr := sc.Properties["url"]
 
-	if got, want := pr.Format, "uri"; got != want {
-		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	testCases := []struct {
+		Field    string
+		Expected string
+	}{
+		{Field: "url", Expected: "uri"},
+		{Field: "email", Expected: "email"},
 	}
 
-	pr = sc.Properties["email"]
+	for _, testCase := range testCases {
+		pr := sc.Properties[testCase.Field]
 
-	if got, want := pr.Format, "email"; got != want {
-		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+		if got, want := pr.Format, testCase.Expected; got != want {
+			t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+		}
 	}
 }
 

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -580,3 +580,101 @@ func TestTimeField(t *testing.T) {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
 }
+
+type URLField string
+type EmailField string
+
+type customSchemaFormatHolder struct {
+	URL   URLField   `json:"url"`
+	Email EmailField `json:"email"`
+}
+
+func TestCustomSchemaFormatHandler(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{
+		SchemaFormatHandler: func(modelName string) string {
+			switch modelName {
+			case "restfulspec.URLField":
+				return "uri"
+			case "restfulspec.EmailField":
+				return "email"
+			}
+
+			return ""
+		},
+	}}
+	db.addModelFrom(customSchemaFormatHolder{})
+	sc := db.Definitions["restfulspec.customSchemaFormatHolder"]
+	pr := sc.Properties["url"]
+
+	if got, want := pr.Format, "uri"; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+
+	pr = sc.Properties["email"]
+
+	if got, want := pr.Format, "email"; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+}
+
+type exampleTagHolder struct {
+	URL         string                      `json:"url" example:"https://example.com"`
+	URLs        []string                    `json:"urls" example:"[\"https://example.com\"]"`
+	Email       string                      `json:"email" example:"test@example.com"`
+	Status      string                      `json:"status"`
+	Description simpleChildExampleTagHolder `json:"description" example:"Test description"`
+	Companies   []childExampleTagHolder     `json:"companies"`
+}
+
+type childExampleTagHolder struct {
+	Name string `json:"name" example:"Company A"`
+}
+
+type simpleChildExampleTagHolder string
+
+func TestCustomTagHandler(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
+	db.addModelFrom(exampleTagHolder{})
+	sc := db.Definitions["restfulspec.exampleTagHolder"]
+
+	pr := sc.Properties["url"]
+
+	testCases := []struct {
+		Field    string
+		Expected string
+	}{
+		{Field: "url", Expected: "https://example.com"},
+		{Field: "urls", Expected: "[\"https://example.com\"]"},
+		{Field: "email", Expected: "test@example.com"},
+		{Field: "description", Expected: "Test description"},
+	}
+
+	for _, testCase := range testCases {
+		pr = sc.Properties[testCase.Field]
+
+		if got, want := pr.Example, testCase.Expected; got != want {
+			t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+		}
+	}
+
+	// Test fields without examples and `companies` child structs.
+	nilTestCases := []string{
+		"status",
+		"companies",
+	}
+
+	for _, testCase := range nilTestCases {
+		pr = sc.Properties[testCase]
+
+		if got := pr.Example; got != nil {
+			t.Errorf("got [%v:%T] want [%v:%T]", got, got, nil, nil)
+		}
+	}
+
+	sc = db.Definitions["restfulspec.childExampleTagHolder"]
+	pr = sc.Properties["name"]
+
+	if got, want := pr.Example, "Company A"; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+}

--- a/property_ext.go
+++ b/property_ext.go
@@ -123,6 +123,12 @@ func setReadOnly(prop *spec.Schema, field reflect.StructField) {
 	}
 }
 
+func setExample(prop *spec.Schema, field reflect.StructField) {
+	if exampleTag := field.Tag.Get("example"); exampleTag != "" {
+		prop.Example = exampleTag
+	}
+}
+
 func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setDescription(prop, field)
 	setDefaultValue(prop, field)
@@ -135,4 +141,5 @@ func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setReadOnly(prop, field)
 	setIsNullableValue(prop, field)
 	setGoNameValue(prop, field)
+	setExample(prop, field)
 }


### PR DESCRIPTION
At the moment, we can't really provide `example` in the Swagger output. This may lead to confusion when it comes to learning what the example values can be.

For example, the field name is `url` and the type is `string`. But we don't know if the URL is HTTPS URL (resolve via DNS) or, say, internal network e.g. `http://internal-service`. By providing the `example` tag, we can output a better Swagger JSON since it's enhanced with examples.

In this PR, I also provided 2 tests, 1 test is for testing the `SchemaFormatHandler` function in the `Config` (which I believe we don't have yet) and another one is for testing the `example` tag.

Let me know if you have feedback about this PR. Thanks!