### PR TITLE
feat: add legacy struct tag support for oastools builder

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,6 +91,13 @@ type Config struct {
 	PostBuildOAS2Handler func(doc *parser.OAS2Document)
 	// [optional] PostBuildOAS3Handler is called after building an OAS 3.x document.
 	PostBuildOAS3Handler func(doc *parser.OAS3Document)
+	// [optional] LegacyStructTags enables support for go-restful-openapi's legacy struct tags.
+	// When true, struct tags like `description`, `minimum`, `maximum`, `enum`, `format`, `type`,
+	// `unique`, `readOnly`, `optional`, `example`, `default`, `x-nullable`, and `x-go-name`
+	// are processed in addition to the standard `oas:"..."` tags.
+	// Legacy tags are only applied to fields that do NOT have an `oas:"..."` tag.
+	// Default is false. Only applies to BuildOAS2/BuildOAS3.
+	LegacyStructTags bool
 }
 
 // Validate checks the Config for common misconfigurations and returns an error if any are found.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/emicklei/go-restful-openapi/v2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.13.0
-	github.com/erraggy/oastools v1.33.0
+	github.com/erraggy/oastools v1.36.1
 	github.com/go-openapi/spec v0.22.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bF
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/erraggy/oastools v1.33.0 h1:FFP33XaCvIxQ2RQGcBRwCEGVZJPfnol/q/jDMgPrFes=
 github.com/erraggy/oastools v1.33.0/go.mod h1:KVEs42aJN9Z+H9YpxqjGrXJRQdrp1W0aJ4w2R+UId+I=
+github.com/erraggy/oastools v1.36.1 h1:mNxGZO1w7LCFmZhar9QPOhLFpchE0T9TzNwqa+rENN4=
+github.com/erraggy/oastools v1.36.1/go.mod h1:KVEs42aJN9Z+H9YpxqjGrXJRQdrp1W0aJ4w2R+UId+I=
 github.com/go-openapi/jsonpointer v0.22.4 h1:dZtK82WlNpVLDW2jlA1YCiVJFVqkED1MegOUy9kR5T4=
 github.com/go-openapi/jsonpointer v0.22.4/go.mod h1:elX9+UgznpFhgBuaMQ7iu4lvvX1nvNsesQ3oxmYTw80=
 github.com/go-openapi/jsonreference v0.21.4 h1:24qaE2y9bx/q3uRK/qN+TDwbok1NhbSmGjjySRCHtC8=

--- a/oastools_builder.go
+++ b/oastools_builder.go
@@ -47,6 +47,11 @@ func BuildOAS2(config Config) (*OAS2Document, error) {
 		doc.Schemes = config.Schemes
 	}
 
+	// Apply legacy optional tag post-processing
+	if config.LegacyStructTags && doc.Definitions != nil {
+		applyLegacyOptionalToSchemas(doc.Definitions)
+	}
+
 	// Call post-build handler if set
 	if config.PostBuildOAS2Handler != nil {
 		config.PostBuildOAS2Handler(doc)
@@ -106,6 +111,11 @@ func BuildOAS3(config Config) (*OAS3Document, error) {
 		return nil, err
 	}
 
+	// Apply legacy optional tag post-processing
+	if config.LegacyStructTags && doc.Components != nil && doc.Components.Schemas != nil {
+		applyLegacyOptionalToSchemas(doc.Components.Schemas)
+	}
+
 	// Call post-build handler if set
 	if config.PostBuildOAS3Handler != nil {
 		config.PostBuildOAS3Handler(doc)
@@ -133,6 +143,11 @@ func newOASBuilder(config Config, version parser.OASVersion) *builder.Builder {
 	// Semantic deduplication
 	if config.SemanticDeduplication {
 		opts = append(opts, builder.WithSemanticDeduplication(true))
+	}
+
+	// Legacy struct tag support
+	if config.LegacyStructTags {
+		opts = append(opts, builder.WithSchemaFieldProcessor(legacyTagFieldProcessor))
 	}
 
 	return builder.New(version, opts...)

--- a/oastools_builder_test.go
+++ b/oastools_builder_test.go
@@ -795,3 +795,398 @@ func TestBuildOAS3_ParameterWithFormat(t *testing.T) {
 		t.Errorf("Expected updated_after format 'date-time', got '%s'", updatedAfterParam.Schema.Format)
 	}
 }
+
+// --- Legacy Struct Tag Tests ---
+
+// TestLegacyTagUser demonstrates a type using go-restful-openapi's legacy struct tags.
+type TestLegacyTagUser struct {
+	ID          int     `json:"id"`
+	Name        string  `json:"name" description:"User's full name"`
+	Email       string  `json:"email" format:"email"`
+	Age         int     `json:"age,omitempty" minimum:"0" maximum:"150"`
+	Role        string  `json:"role" enum:"admin|user|guest"`
+	Score       float64 `json:"score" default:"0.0"`
+	IsActive    bool    `json:"is_active" readOnly:"true"`
+	Tags        string  `json:"tags" type:"[]string" unique:"true"`
+	NullableRef *string `json:"nullable_ref" x-nullable:"true"`
+	GoName      string  `json:"go_name" x-go-name:"CustomGoName"`
+	Example     string  `json:"example" example:"test@example.com"`
+	Nickname    string  `json:"nickname" optional:"true"` // Should NOT be in required array
+}
+
+// TestMalformedTagUser has invalid struct tag values to test graceful degradation.
+type TestMalformedTagUser struct {
+	BadMin int `json:"bad_min" minimum:"not-a-number"`
+	BadMax int `json:"bad_max" maximum:"invalid"`
+}
+
+// TestMixedTagUser has both legacy and oas tags - oas should take precedence.
+type TestMixedTagUser struct {
+	// Field with oas tag - should use oas, ignore legacy
+	ID int `json:"id" oas:"description=OAS ID description" description:"Legacy ID description"`
+	// Field with only legacy tags
+	Name string `json:"name" description:"User name from legacy"`
+}
+
+func TestBuildOAS2_LegacyStructTags(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listLegacyUsers").
+		Writes([]TestLegacyTagUser{}).
+		Returns(http.StatusOK, "OK", []TestLegacyTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		LegacyStructTags: true, // Enable legacy struct tag support
+	}
+
+	doc, err := BuildOAS2(config)
+	if err != nil {
+		t.Fatalf("BuildOAS2 failed: %v", err)
+	}
+
+	// Find the schema
+	schema, ok := doc.Definitions["TestLegacyTagUser"]
+	if !ok {
+		t.Logf("Available definitions: %v", keysOf(doc.Definitions))
+		t.Fatal("Expected TestLegacyTagUser definition")
+	}
+
+	// Verify description tag
+	nameField := schema.Properties["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' property")
+	}
+	if nameField.Description != "User's full name" {
+		t.Errorf("Expected description 'User's full name', got '%s'", nameField.Description)
+	}
+
+	// Verify format tag
+	emailField := schema.Properties["email"]
+	if emailField == nil {
+		t.Fatal("Expected 'email' property")
+	}
+	if emailField.Format != "email" {
+		t.Errorf("Expected format 'email', got '%s'", emailField.Format)
+	}
+
+	// Verify minimum/maximum tags
+	ageField := schema.Properties["age"]
+	if ageField == nil {
+		t.Fatal("Expected 'age' property")
+	}
+	if ageField.Minimum == nil || *ageField.Minimum != 0 {
+		t.Errorf("Expected minimum 0, got %v", ageField.Minimum)
+	}
+	if ageField.Maximum == nil || *ageField.Maximum != 150 {
+		t.Errorf("Expected maximum 150, got %v", ageField.Maximum)
+	}
+
+	// Verify enum tag
+	roleField := schema.Properties["role"]
+	if roleField == nil {
+		t.Fatal("Expected 'role' property")
+	}
+	if len(roleField.Enum) != 3 {
+		t.Errorf("Expected 3 enum values, got %d", len(roleField.Enum))
+	}
+
+	// Verify readOnly tag
+	isActiveField := schema.Properties["is_active"]
+	if isActiveField == nil {
+		t.Fatal("Expected 'is_active' property")
+	}
+	if !isActiveField.ReadOnly {
+		t.Error("Expected is_active to be readOnly")
+	}
+
+	// Verify type tag (array override)
+	tagsField := schema.Properties["tags"]
+	if tagsField == nil {
+		t.Fatal("Expected 'tags' property")
+	}
+	if tagsField.Type != "array" {
+		t.Errorf("Expected type 'array', got '%v'", tagsField.Type)
+	}
+	if !tagsField.UniqueItems {
+		t.Error("Expected uniqueItems to be true")
+	}
+
+	// Verify example tag
+	exampleField := schema.Properties["example"]
+	if exampleField == nil {
+		t.Fatal("Expected 'example' property")
+	}
+	if exampleField.Example != "test@example.com" {
+		t.Errorf("Expected example 'test@example.com', got '%v'", exampleField.Example)
+	}
+
+	// Verify x-nullable extension
+	nullableField := schema.Properties["nullable_ref"]
+	if nullableField == nil {
+		t.Fatal("Expected 'nullable_ref' property")
+	}
+	if nullableField.Extra == nil || nullableField.Extra["x-nullable"] != true {
+		t.Error("Expected x-nullable extension to be true")
+	}
+
+	// Verify x-go-name extension
+	goNameField := schema.Properties["go_name"]
+	if goNameField == nil {
+		t.Fatal("Expected 'go_name' property")
+	}
+	if goNameField.Extra == nil || goNameField.Extra["x-go-name"] != "CustomGoName" {
+		t.Errorf("Expected x-go-name 'CustomGoName', got %v", goNameField.Extra["x-go-name"])
+	}
+
+	// Verify default tag
+	scoreField := schema.Properties["score"]
+	if scoreField == nil {
+		t.Fatal("Expected 'score' property")
+	}
+	if scoreField.Default != 0.0 {
+		t.Errorf("Expected default 0.0, got %v (type %T)", scoreField.Default, scoreField.Default)
+	}
+
+	// Verify optional tag - nickname should NOT be in required array
+	nicknameField := schema.Properties["nickname"]
+	if nicknameField == nil {
+		t.Fatal("Expected 'nickname' property")
+	}
+	// The x-restful-optional extension should be cleaned up
+	if nicknameField.Extra != nil && nicknameField.Extra["x-restful-optional"] != nil {
+		t.Error("Expected x-restful-optional extension to be cleaned up")
+	}
+	// nickname should not be in required array
+	for _, req := range schema.Required {
+		if req == "nickname" {
+			t.Error("Expected 'nickname' to NOT be in required array (has optional:\"true\")")
+		}
+	}
+}
+
+func TestBuildOAS2_LegacyStructTagsDisabled(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listLegacyUsersDisabled").
+		Writes([]TestLegacyTagUser{}).
+		Returns(http.StatusOK, "OK", []TestLegacyTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		LegacyStructTags: false, // Legacy struct tags disabled (default)
+	}
+
+	doc, err := BuildOAS2(config)
+	if err != nil {
+		t.Fatalf("BuildOAS2 failed: %v", err)
+	}
+
+	schema, ok := doc.Definitions["TestLegacyTagUser"]
+	if !ok {
+		t.Logf("Available definitions: %v", keysOf(doc.Definitions))
+		t.Fatal("Expected TestLegacyTagUser definition")
+	}
+
+	// With legacy tags disabled, description should NOT be set from legacy tag
+	nameField := schema.Properties["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' property")
+	}
+	if nameField.Description == "User's full name" {
+		t.Error("Legacy tags should not be applied when LegacyStructTags is false")
+	}
+}
+
+func TestBuildOAS2_LegacyTagsSkippedWhenOASTagPresent(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listMixedTagUsers").
+		Writes([]TestMixedTagUser{}).
+		Returns(http.StatusOK, "OK", []TestMixedTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		LegacyStructTags: true,
+	}
+
+	doc, err := BuildOAS2(config)
+	if err != nil {
+		t.Fatalf("BuildOAS2 failed: %v", err)
+	}
+
+	schema, ok := doc.Definitions["TestMixedTagUser"]
+	if !ok {
+		t.Logf("Available definitions: %v", keysOf(doc.Definitions))
+		t.Fatal("Expected TestMixedTagUser definition")
+	}
+
+	// ID field has oas tag - should use OAS description, not legacy
+	idField := schema.Properties["id"]
+	if idField == nil {
+		t.Fatal("Expected 'id' property")
+	}
+	if idField.Description != "OAS ID description" {
+		t.Errorf("Expected OAS description 'OAS ID description', got '%s'", idField.Description)
+	}
+	if idField.Description == "Legacy ID description" {
+		t.Error("Legacy description should not override OAS tag")
+	}
+
+	// Name field only has legacy tag - should use legacy description
+	nameField := schema.Properties["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' property")
+	}
+	if nameField.Description != "User name from legacy" {
+		t.Errorf("Expected legacy description 'User name from legacy', got '%s'", nameField.Description)
+	}
+}
+
+func TestBuildOAS3_LegacyStructTags(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listLegacyUsersOAS3").
+		Writes([]TestLegacyTagUser{}).
+		Returns(http.StatusOK, "OK", []TestLegacyTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		OASVersion:       OASVersion320,
+		LegacyStructTags: true,
+	}
+
+	doc, err := BuildOAS3(config)
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	// In OAS3, schemas are in Components.Schemas
+	if doc.Components == nil || doc.Components.Schemas == nil {
+		t.Fatal("Expected components.schemas to be non-nil")
+	}
+
+	schema, ok := doc.Components.Schemas["TestLegacyTagUser"]
+	if !ok {
+		t.Logf("Available schemas: %v", keysOf(doc.Components.Schemas))
+		t.Fatal("Expected TestLegacyTagUser schema")
+	}
+
+	// Verify description tag works in OAS3
+	nameField := schema.Properties["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' property")
+	}
+	if nameField.Description != "User's full name" {
+		t.Errorf("Expected description 'User's full name', got '%s'", nameField.Description)
+	}
+
+	// Verify format tag works in OAS3
+	emailField := schema.Properties["email"]
+	if emailField == nil {
+		t.Fatal("Expected 'email' property")
+	}
+	if emailField.Format != "email" {
+		t.Errorf("Expected format 'email', got '%s'", emailField.Format)
+	}
+}
+
+func TestBuildOAS2_LegacyMalformedTags(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listMalformedUsers").
+		Writes([]TestMalformedTagUser{}).
+		Returns(http.StatusOK, "OK", []TestMalformedTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		LegacyStructTags: true,
+	}
+
+	// Should not error - malformed tags are gracefully ignored with logging
+	doc, err := BuildOAS2(config)
+	if err != nil {
+		t.Fatalf("BuildOAS2 failed: %v", err)
+	}
+
+	schema, ok := doc.Definitions["TestMalformedTagUser"]
+	if !ok {
+		t.Logf("Available definitions: %v", keysOf(doc.Definitions))
+		t.Fatal("Expected TestMalformedTagUser definition")
+	}
+
+	// Verify invalid minimum tag is gracefully ignored (Minimum remains nil)
+	badMinField := schema.Properties["bad_min"]
+	if badMinField == nil {
+		t.Fatal("Expected 'bad_min' property")
+	}
+	if badMinField.Minimum != nil {
+		t.Errorf("Expected Minimum to be nil for invalid tag, got %v", *badMinField.Minimum)
+	}
+
+	// Verify invalid maximum tag is gracefully ignored (Maximum remains nil)
+	badMaxField := schema.Properties["bad_max"]
+	if badMaxField == nil {
+		t.Fatal("Expected 'bad_max' property")
+	}
+	if badMaxField.Maximum != nil {
+		t.Errorf("Expected Maximum to be nil for invalid tag, got %v", *badMaxField.Maximum)
+	}
+}
+
+func TestBuildOAS3_LegacyOptionalTag(t *testing.T) {
+	ws := new(restful.WebService)
+	ws.Path("/users")
+	ws.Route(ws.GET("").To(dummyHandler).
+		Operation("listOptionalUsersOAS3").
+		Writes([]TestLegacyTagUser{}).
+		Returns(http.StatusOK, "OK", []TestLegacyTagUser{}))
+
+	config := Config{
+		WebServices:      []*restful.WebService{ws},
+		SchemaNaming:     SchemaNamingTypeOnly,
+		OASVersion:       OASVersion320,
+		LegacyStructTags: true,
+	}
+
+	doc, err := BuildOAS3(config)
+	if err != nil {
+		t.Fatalf("BuildOAS3 failed: %v", err)
+	}
+
+	if doc.Components == nil || doc.Components.Schemas == nil {
+		t.Fatal("Expected components.schemas to be non-nil")
+	}
+
+	schema, ok := doc.Components.Schemas["TestLegacyTagUser"]
+	if !ok {
+		t.Logf("Available schemas: %v", keysOf(doc.Components.Schemas))
+		t.Fatal("Expected TestLegacyTagUser schema")
+	}
+
+	// Verify optional tag works in OAS3 - nickname should NOT be in required array
+	for _, req := range schema.Required {
+		if req == "nickname" {
+			t.Error("Expected 'nickname' to NOT be in required array (has optional:\"true\")")
+		}
+	}
+
+	// The x-restful-optional extension should be cleaned up
+	nicknameField := schema.Properties["nickname"]
+	if nicknameField == nil {
+		t.Fatal("Expected 'nickname' property")
+	}
+	if nicknameField.Extra != nil && nicknameField.Extra["x-restful-optional"] != nil {
+		t.Error("Expected x-restful-optional extension to be cleaned up")
+	}
+}

--- a/oastools_schema.go
+++ b/oastools_schema.go
@@ -1,6 +1,7 @@
 package restfulspec
 
 import (
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -8,10 +9,22 @@ import (
 	"github.com/erraggy/oastools/parser"
 )
 
+// legacyOptionalExtension is the extension key used to mark fields as optional
+// during schema generation. This is cleaned up in post-processing.
+const legacyOptionalExtension = "x-restful-optional"
+
+// legacyTagFieldProcessor is a schema field processor that applies go-restful-openapi's
+// legacy struct tags to schemas. This is used with oastools' WithSchemaFieldProcessor option.
+// Legacy tags are only applied to fields that do NOT have an oas:"..." tag.
+func legacyTagFieldProcessor(schema *parser.Schema, field reflect.StructField) *parser.Schema {
+	// Only apply legacy tags if the field doesn't have an oas:"..." tag
+	if hasOASTag(field) {
+		return schema
+	}
+	return applyLegacyTags(schema, field)
+}
+
 // hasOASTag returns true if the field has an oas:"..." struct tag.
-// This function is reserved for future dual tag support integration.
-//
-//nolint:unused
 func hasOASTag(field reflect.StructField) bool {
 	return field.Tag.Get("oas") != ""
 }
@@ -20,9 +33,6 @@ func hasOASTag(field reflect.StructField) bool {
 // This is only called when the field does NOT have an oas:"..." tag.
 // Supported legacy tags: description, minimum, maximum, enum, format, type,
 // unique, readOnly, optional, example, default, x-nullable, x-go-name
-// This function is reserved for future dual tag support integration.
-//
-//nolint:unused
 func applyLegacyTags(schema *parser.Schema, field reflect.StructField) *parser.Schema {
 	if schema == nil {
 		return nil
@@ -40,6 +50,8 @@ func applyLegacyTags(schema *parser.Schema, field reflect.StructField) *parser.S
 	if tag := field.Tag.Get("minimum"); tag != "" {
 		if f, err := strconv.ParseFloat(tag, 64); err == nil {
 			result.Minimum = &f
+		} else {
+			log.Printf("restfulspec: field %q has invalid minimum tag %q: %v", field.Name, tag, err)
 		}
 	}
 
@@ -47,6 +59,8 @@ func applyLegacyTags(schema *parser.Schema, field reflect.StructField) *parser.S
 	if tag := field.Tag.Get("maximum"); tag != "" {
 		if f, err := strconv.ParseFloat(tag, 64); err == nil {
 			result.Maximum = &f
+		} else {
+			log.Printf("restfulspec: field %q has invalid maximum tag %q: %v", field.Name, tag, err)
 		}
 	}
 
@@ -111,12 +125,32 @@ func applyLegacyTags(schema *parser.Schema, field reflect.StructField) *parser.S
 		result.Extra["x-go-name"] = tag
 	}
 
+	// optional tag - marks field as not required
+	// This is processed via extension and cleaned up in post-processing
+	// because the required array is on the parent schema, not the field schema.
+	if tag := field.Tag.Get("optional"); tag == "true" {
+		if result.Extra == nil {
+			result.Extra = make(map[string]any)
+		}
+		// Get the JSON field name for removal from required array
+		jsonName := field.Name
+		if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+			parts := strings.Split(jsonTag, ",")
+			if parts[0] != "" && parts[0] != "-" {
+				jsonName = parts[0]
+			}
+		}
+		result.Extra[legacyOptionalExtension] = jsonName
+	}
+
 	return result
 }
 
 // isLegacyFieldRequired determines if a field should be required based on legacy tags.
 // Returns true if the field should be required, false otherwise.
-// This function is reserved for future dual tag support integration.
+// Note: This function is reserved for future integration when oastools adds support
+// for customizing required field behavior. Currently, required fields are determined
+// by oastools based on pointer types and omitempty tags.
 //
 //nolint:unused
 func isLegacyFieldRequired(field reflect.StructField) bool {
@@ -144,9 +178,6 @@ func isLegacyFieldRequired(field reflect.StructField) bool {
 }
 
 // shallowCopySchema creates a shallow copy of a schema for modification.
-// This function is reserved for future dual tag support integration.
-//
-//nolint:unused
 func shallowCopySchema(s *parser.Schema) *parser.Schema {
 	if s == nil {
 		return nil
@@ -224,9 +255,6 @@ func shallowCopySchema(s *parser.Schema) *parser.Schema {
 }
 
 // parseLegacyDefaultValue parses a default value string based on the schema type.
-// This function is reserved for future dual tag support integration.
-//
-//nolint:unused
 func parseLegacyDefaultValue(value string, schemaType any) any {
 	typeStr, ok := schemaType.(string)
 	if !ok {
@@ -238,13 +266,95 @@ func parseLegacyDefaultValue(value string, schemaType any) any {
 		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
 			return n
 		}
+		log.Printf("restfulspec: invalid default value %q for integer type: falling back to string", value)
 	case "number":
 		if f, err := strconv.ParseFloat(value, 64); err == nil {
 			return f
 		}
+		log.Printf("restfulspec: invalid default value %q for number type: falling back to string", value)
 	case "boolean":
 		return value == "true"
 	}
 
 	return value
+}
+
+// applyLegacyOptionalToSchemas processes all schemas in a map and removes fields
+// marked with x-restful-optional from the required arrays, then cleans up the extension.
+func applyLegacyOptionalToSchemas(schemas map[string]*parser.Schema) {
+	for _, schema := range schemas {
+		applyLegacyOptionalToSchema(schema)
+	}
+}
+
+// applyLegacyOptionalToSchema processes a single schema and its nested properties.
+func applyLegacyOptionalToSchema(schema *parser.Schema) {
+	if schema == nil {
+		return
+	}
+
+	// Collect field names that should be removed from required
+	var optionalFields []string
+
+	// Process properties
+	for propName, propSchema := range schema.Properties {
+		if propSchema == nil {
+			continue
+		}
+
+		// Check for the optional extension
+		if propSchema.Extra != nil {
+			if jsonName, ok := propSchema.Extra[legacyOptionalExtension].(string); ok {
+				optionalFields = append(optionalFields, jsonName)
+				// Clean up the extension
+				delete(propSchema.Extra, legacyOptionalExtension)
+				if len(propSchema.Extra) == 0 {
+					propSchema.Extra = nil
+				}
+			}
+		}
+
+		// Recursively process nested schemas
+		applyLegacyOptionalToSchema(propSchema)
+
+		// Also check if the property name matches what we collected
+		_ = propName // propName is used implicitly via propSchema
+	}
+
+	// Remove optional fields from the required array
+	if len(optionalFields) > 0 && len(schema.Required) > 0 {
+		optionalSet := make(map[string]bool, len(optionalFields))
+		for _, f := range optionalFields {
+			optionalSet[f] = true
+		}
+
+		newRequired := make([]string, 0, len(schema.Required))
+		for _, req := range schema.Required {
+			if !optionalSet[req] {
+				newRequired = append(newRequired, req)
+			}
+		}
+		schema.Required = newRequired
+	}
+
+	// Process nested schemas in Items, AllOf, AnyOf, OneOf
+	if schema.Items != nil {
+		if itemSchema, ok := schema.Items.(*parser.Schema); ok {
+			applyLegacyOptionalToSchema(itemSchema)
+		}
+	}
+	for _, s := range schema.AllOf {
+		applyLegacyOptionalToSchema(s)
+	}
+	for _, s := range schema.AnyOf {
+		applyLegacyOptionalToSchema(s)
+	}
+	for _, s := range schema.OneOf {
+		applyLegacyOptionalToSchema(s)
+	}
+	if schema.AdditionalProperties != nil {
+		if addPropSchema, ok := schema.AdditionalProperties.(*parser.Schema); ok {
+			applyLegacyOptionalToSchema(addPropSchema)
+		}
+	}
 }


### PR DESCRIPTION
## Preface

@emicklei After trying to utilize this in an internal fork, I discovered that this was lacking in my initial implementation and so I added additional functionality to `oastools` first, and then utilized it here to complete the gaps. After this is merged, I believe you should be able to cut a new release tag to make this available. If you require anything additional to make that happen, please let me know.

Happy Holidays, and I wish a healthy and prosperous new year to you and yours!

## Summary

- Add `LegacyStructTags` config option to enable go-restful-openapi's legacy struct tags when using `BuildOAS2`/`BuildOAS3`
- Upgrade oastools from v1.33.0 to v1.36.1 to use the new `WithSchemaFieldProcessor` hook
- Add comprehensive tests for all legacy tag behaviors

## Motivation

This provides a migration path for users transitioning from `BuildSwagger` to the new oastools-based builders. Users can enable legacy struct tag support with a single config option, allowing their existing struct definitions to work without modification.

## Supported Legacy Tags

| Tag | Description |
|-----|-------------|
| `description:"..."` | Field description |
| `minimum:"N"` | Minimum numeric value |
| `maximum:"N"` | Maximum numeric value |
| `format:"..."` | OpenAPI format (email, uuid, date, etc.) |
| `type:"..."` | Override Go type (supports `[]string` for arrays) |
| `enum:"a\|b\|c"` | Allowed values (pipe-separated) |
| `unique:"true"` | Array items must be unique |
| `readOnly:"true"` | Field is read-only |
| `optional:"true"` | Field is not required |
| `example:"..."` | Example value |
| `default:"..."` | Default value (type-aware parsing) |
| `x-nullable:"true"` | Nullable extension |
| `x-go-name:"..."` | Custom Go name extension |

## Key Features

- **Opt-in behavior**: `LegacyStructTags: false` by default
- **OAS tag precedence**: Legacy tags are skipped when `oas:"..."` is present
- **Graceful degradation**: Invalid tag values are logged but don't cause errors
- **Works with both OAS 2.0 and OAS 3.x**

## Usage

```go
config := restfulspec.Config{
    WebServices:      []*restful.WebService{ws},
    LegacyStructTags: true,  // Enable legacy struct tags
}
doc, err := restfulspec.BuildOAS2(config)
// or
doc, err := restfulspec.BuildOAS3(config)
```

## Test plan

- [x] `TestBuildOAS2_LegacyStructTags` - verifies all legacy tags work in OAS 2.0
- [x] `TestBuildOAS2_LegacyStructTagsDisabled` - verifies legacy tags are off by default
- [x] `TestBuildOAS2_LegacyTagsSkippedWhenOASTagPresent` - verifies OAS tags take precedence
- [x] `TestBuildOAS3_LegacyStructTags` - verifies legacy tags work in OAS 3.x
- [x] `TestBuildOAS2_LegacyMalformedTags` - verifies graceful degradation for invalid values
- [x] `TestBuildOAS3_LegacyOptionalTag` - verifies optional tag works in OAS 3.x
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)